### PR TITLE
画面追加と共通コンポーネント整備

### DIFF
--- a/src/app/cat/page.tsx
+++ b/src/app/cat/page.tsx
@@ -1,0 +1,16 @@
+import BackButton from "@/components/BackButton";
+import TypewriterText from "@/components/TypewriterText";
+import WindowPanel from "@/components/WindowPanel";
+
+export default function CatPage() {
+  return (
+    <main className="flex flex-1 items-center justify-center">
+      <WindowPanel>
+        <p className="w-full text-left text-base sm:text-xl">
+          <TypewriterText text="にゃ～ん。" />
+        </p>
+        <BackButton />
+      </WindowPanel>
+    </main>
+  );
+}

--- a/src/app/guest-start/page.tsx
+++ b/src/app/guest-start/page.tsx
@@ -1,0 +1,16 @@
+import BackButton from "@/components/BackButton";
+import TypewriterText from "@/components/TypewriterText";
+import WindowPanel from "@/components/WindowPanel";
+
+export default function BlockedStartPage() {
+  return (
+    <main className="flex flex-1 items-center justify-center">
+      <WindowPanel>
+        <p className="w-full text-left text-base sm:text-xl">
+          <TypewriterText text="しかし まわりこまれてしまった" />
+        </p>
+        <BackButton />
+      </WindowPanel>
+    </main>
+  );
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+import MenuItem from "@/components/MenuItem";
+import WindowPanel from "@/components/WindowPanel";
+
+const MENU = [
+  {
+    label: "遊ぶ",
+    children: [
+      {
+        label: "シングルモード",
+        href: "/single",
+      },
+      {
+        label: "対戦モード",
+        href: "/battle",
+      },
+    ],
+  },
+  {
+    label: "ランキング",
+    href: "/rankings",
+  },
+  {
+    label: "スコア履歴",
+    href: "/score-history",
+  },
+  {
+    label: "🐱",
+    href: "/cat",
+  },
+  {
+    label: "💀",
+    href: "/skull",
+  },
+] as const;
+
+export default function HomePage() {
+  return (
+    <main className="flex flex-1 items-center justify-center">
+      <WindowPanel>
+        <h1 className="text-3xl font-bold drop-shadow-[4px_4px_0_#64748b] sm:text-5xl">
+          ホーム
+        </h1>
+        <nav className="mt-10 flex w-full max-w-md flex-col items-start gap-5">
+          {MENU.map((item) => {
+            if ("children" in item) {
+              return (
+                <div key={item.label} className="flex w-full flex-col items-start">
+                  <MenuItem showCursor>{item.label}</MenuItem>
+
+                  <div className="mt-4 ml-12 flex flex-col items-start gap-3">
+                    {item.children.map((child) => (
+                      <Link key={child.href} href={child.href}>
+                        <MenuItem>{child.label}</MenuItem>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              );
+            }
+
+            return (
+              <Link key={item.href} href={item.href}>
+                <MenuItem showCursor>{item.label}</MenuItem>
+              </Link>
+            );
+          })}
+        </nav>
+      </WindowPanel>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,28 @@
+import Link from "next/link";
+
 import MenuItem from "@/components/MenuItem";
+import WindowPanel from "@/components/WindowPanel";
 
 export default function TopPage() {
   return (
     <main className="flex flex-1 items-center justify-center">
-      <section className="mx-auto flex w-full max-w-4xl flex-col items-center border-4 border-white bg-[#07133a] p-6 text-center sm:p-10">
+      <WindowPanel>
         <h1 className="transform-[perspective(320px)_rotateX(12deg)_skewX(-8deg)_scaleY(1.08)] text-4xl font-bold drop-shadow-[4px_4px_0_#64748b] sm:text-6xl">
-          Type-Clash
+          Type★Clash
         </h1>
         <p className="mt-6 text-base sm:text-xl">
           リアルタイム対戦型タイピングアプリ
         </p>
-        <div className="mt-10">
-          <MenuItem selected>スタート</MenuItem>
+        <div className="mt-10 flex flex-col items-start gap-5">
+          <Link href="/login">
+            <MenuItem showCursor>ログイン</MenuItem>
+          </Link>
+
+          <Link href="/guest-start">
+            <MenuItem showCursor>ログインしないでスタート</MenuItem>
+          </Link>
         </div>
-      </section>
+      </WindowPanel>
     </main>
   );
 }

--- a/src/app/skull/page.tsx
+++ b/src/app/skull/page.tsx
@@ -1,0 +1,16 @@
+import BackButton from "@/components/BackButton";
+import TypewriterText from "@/components/TypewriterText";
+import WindowPanel from "@/components/WindowPanel";
+
+export default function SkullPage() {
+  return (
+    <main className="flex flex-1 items-center justify-center">
+      <WindowPanel>
+        <p className="w-full text-left text-base sm:text-xl">
+          <TypewriterText text="へんじがない。ただの しかばね のようだ。" />
+        </p>
+        <BackButton />
+      </WindowPanel>
+    </main>
+  );
+}

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function BackButton() {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.back()}
+      className="mt-8 self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+    >
+      ▶ 戻る
+    </button>
+  );
+}

--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -1,16 +1,19 @@
 type MenuItemProps = Readonly<{
   children: React.ReactNode;
-  selected?: boolean;
+  showCursor?: boolean;
 }>;
 
-export default function MenuItem({ children, selected = false }: MenuItemProps) {
+export default function MenuItem({
+  children,
+  showCursor = false,
+}: MenuItemProps) {
   return (
     <div className="group inline-flex items-center justify-center gap-3 text-2xl transition-colors hover:text-yellow-200 sm:text-3xl">
       <span
         className="w-6 shrink-0 transition-transform group-hover:translate-x-1"
         aria-hidden="true"
       >
-        {selected ? "▶" : ""}
+        {showCursor ? "▶" : ""}
       </span>
       <span>{children}</span>
     </div>

--- a/src/components/TypewriterText.tsx
+++ b/src/components/TypewriterText.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type TypewriterTextProps = Readonly<{
+  text: string;
+  speed?: number;
+}>;
+
+export default function TypewriterText({
+  text,
+  speed = 70,
+}: TypewriterTextProps) {
+  const [visibleLength, setVisibleLength] = useState(0);
+  const characters = Array.from(text);
+
+  useEffect(() => {
+    const timerId = globalThis.setInterval(() => {
+      setVisibleLength((currentLength) => {
+        const nextLength = currentLength + 1;
+
+        if (nextLength >= characters.length) {
+          globalThis.clearInterval(timerId);
+        }
+
+        return Math.min(nextLength, characters.length);
+      });
+    }, speed);
+
+    return () => globalThis.clearInterval(timerId);
+  }, [characters.length, speed]);
+
+  return <>{characters.slice(0, visibleLength).join("")}</>;
+}

--- a/src/components/WindowPanel.tsx
+++ b/src/components/WindowPanel.tsx
@@ -1,0 +1,11 @@
+type WindowPanelProps = Readonly<{
+  children: React.ReactNode;
+}>;
+
+export default function WindowPanel({ children }: WindowPanelProps) {
+  return (
+    <section className="mx-auto flex w-full max-w-4xl flex-col items-center border-4 border-white bg-[#07133a] p-6 text-center sm:p-10">
+      {children}
+    </section>
+  );
+}


### PR DESCRIPTION
## 概要
画面遷移用のページと共通UIコンポーネントを追加・更新しました。

## 変更内容
- `home` / `cat` / `quest-start` / `skull` ページを追加
- `BackButton`、`TypewriterText`、`WindowPanel` を追加
- `MenuItem` とトップページの表示を調整

## 確認
- 主要画面の表示と遷移を確認
