### PR TITLE
シングルモード、対戦モードの結果画面

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1640,7 +1639,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1700,7 +1698,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2226,7 +2223,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2570,7 +2566,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3138,7 +3133,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3324,7 +3318,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5498,7 +5491,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5508,7 +5500,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6200,7 +6191,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6363,7 +6353,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6639,7 +6628,6 @@
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/result/ButtleResult/page.tsx
+++ b/src/app/result/ButtleResult/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+import WindowPanel from "@/components/WindowPanel";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function BattleResult() {
+
+    interface Result {
+        id: number
+        player1_id: number
+        player2_id: number
+        winner_id: number
+        player1_score: number
+        player2_score: number
+        player1_accuracy_rate: number
+        player2_accuracy_rate: number
+    }
+
+    
+    const [result, setResult] = useState<Result | null>(null)
+    const [displayedText1, setDisplayedText1] = useState("")
+    const [displayedText2, setDisplayedText2] = useState("")
+    const [done, setDone] = useState(false)
+
+    const router = useRouter();
+    const url = "http://localhost:8080"
+
+    //表示時に
+    useEffect(() => {
+        const fetchResult = async () => {
+            try {
+                const res = await fetch(`${url}/api/battle-results`, {
+                    method: "GET",
+                    headers: { 'Content-Type': 'application/json' },
+                })
+                const data: Result = await res.json()
+                setResult(data)
+            } catch {
+                setResult({
+                    id: 1,
+                    player1_id: 1,
+                    player2_id: 2,
+                    winner_id: 1,
+                    player1_score: 100,
+                    player2_score: 80,
+                    player1_accuracy_rate: 89,
+                    player2_accuracy_rate: 90
+                })
+            }
+        }
+        fetchResult()
+    }, [])
+
+    useEffect(() => {
+        if (!result) return;
+
+        const fullText1 = `Player 1\nスコア：${result.player1_score}\n正答率：${result.player1_accuracy_rate}%\n入力文字数:\nミス数:`;
+        const fullText2 = `Player 2\nスコア：${result.player2_score}\n正答率：${result.player2_accuracy_rate}%\n入力文字数:\nミス数:`;
+        let index1 = 0;
+        let index2 = 0;
+        let fin1 = false;
+        let fin2 = false;
+        setDisplayedText1("");
+        setDisplayedText2("");
+        setDone(false);
+
+        const timer = setInterval(() => {
+            if (index1 < fullText1.length) {
+                index1++;
+                setDisplayedText1(fullText1.slice(0, index1));
+                if (index1 >= fullText1.length) fin1 = true;
+            }
+            if (index2 < fullText2.length) {
+                index2++;
+                setDisplayedText2(fullText2.slice(0, index2));
+                if (index2 >= fullText2.length) fin2 = true;
+            }
+            if (fin1 && fin2) {
+                clearInterval(timer);
+                setDone(true);
+            }
+        }, 70);
+
+        return () => clearInterval(timer);
+    }, [result])
+
+    const winnerLabel = result
+        ? result.winner_id === result.player1_id ? "Player 1 の勝利！" : "Player 2 の勝利！"
+        : ""
+
+    return (
+        <div className="flex flex-col items-center gap-6">
+            <div className="flex gap-6">
+                <WindowPanel>
+                    <pre className="whitespace-pre-wrap font-[inherit]">
+                        {displayedText1}
+                    </pre>
+                </WindowPanel>
+                <WindowPanel>
+                    <pre className="whitespace-pre-wrap font-[inherit]">
+                        {displayedText2}
+                    </pre>
+                </WindowPanel>
+            </div>
+            {done && (
+                <WindowPanel>
+                    <p className="text-xl">{winnerLabel}</p>
+                    <div className="flex gap-4 mt-8">
+                        <button
+                            type="button"
+                            onClick={() => router.push('/')}
+                            className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+                        >
+                            ▶ 再挑戦
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => router.push('/home')}
+                            className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+                        >
+                            ▶ home
+                        </button>
+                    </div>
+                </WindowPanel>
+            )}
+        </div>
+    )
+}

--- a/src/app/result/SingleResult/page.tsx
+++ b/src/app/result/SingleResult/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+import BackButton from "@/components/BackButton";
+import WindowPanel from "@/components/WindowPanel";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function SingleResult() {
+
+    interface Result {
+        userid: number
+        score: number
+        accuracy_rate: number
+    }
+
+    const [result, setResult] = useState<Result | null>(null)
+    const [displayedText, setDisplayedText] = useState("")
+    const [done, setDone] = useState(false)
+
+    const router = useRouter();
+    const url = "http://localhost:8080"
+
+    useEffect(() => {
+        const fetchResult = async () => {
+            try {
+                const res = await fetch(`${url}/api/single-results`, {
+                    method: "GET",
+                    headers: { 'Content-Type': 'application/json' },
+                })
+                const data: Result = await res.json()
+                setResult(data)
+            } catch {
+                setResult({ userid: 1, score: 100, accuracy_rate: 80 })
+            }
+        }
+        fetchResult()
+    }, [])
+
+    useEffect(() => {
+        if (!result) return;
+
+        const fullText = `結果\nスコア：${result.score}\n正答率：${result.accuracy_rate}%\n入力文字数:\nミス数:`;
+        let index = 0;
+        setDisplayedText("");
+        setDone(false);
+
+        const timer = setInterval(() => {
+            index++;
+            setDisplayedText(fullText.slice(0, index));
+            if (index >= fullText.length) {
+                clearInterval(timer);
+                setDone(true);
+            }
+        }, 50);
+
+        return () => clearInterval(timer);
+    }, [result])
+
+    return(
+        <>
+           <WindowPanel>
+                <pre className="whitespace-pre-wrap font-[inherit]">
+                    {displayedText}
+                </pre>
+                {done && (
+                    <>
+                        <button
+                            type="button"
+                            onClick={() => router.push('/')}
+                            className="mt-8 self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+                        >
+                            ▶ 再挑戦
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => router.push('/home')}
+                            className="mt-8 self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+                        >
+                            ▶ home
+                        </button>
+                    </>
+                )}
+           </WindowPanel>
+        </>
+    )
+}


### PR DESCRIPTION
- シングルプレイ結果画面（/result/SingleResult）を追加 
  - RPG風タイプライター演出で結果を1文字ずつ出力
  - 表示完了後に「再挑戦」「home」ボタンを表示
 
- バトル結果画面（/result/ButtleResult）を追加
  - Player1・Player2の結果を横並び2パネルで同時表示
  - 両プレイヤーのタイプライター演出が完了後に勝者を表示
  - 表示完了後にボタンを表示