### PR TITLE
シングルモードのフロントエンドを実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1639,6 +1640,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1698,6 +1700,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2223,6 +2226,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2566,6 +2570,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3133,6 +3138,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3318,6 +3324,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5491,6 +5498,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5500,6 +5508,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6191,6 +6200,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6353,6 +6363,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6628,6 +6639,7 @@
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/result/SingleResult/page.tsx
+++ b/src/app/result/SingleResult/page.tsx
@@ -1,44 +1,36 @@
 "use client";
 import BackButton from "@/components/BackButton";
 import WindowPanel from "@/components/WindowPanel";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
-export default function SingleResult() {
-
+function SingleResultContent() {
     interface Result {
-        userid: number
-        score: number
-        accuracy_rate: number
+        score: string;
+        accuracy: string;
+        correct: string;
+        total: string;
     }
 
-    const [result, setResult] = useState<Result | null>(null)
-    const [displayedText, setDisplayedText] = useState("")
-    const [done, setDone] = useState(false)
+    const [displayedText, setDisplayedText] = useState("");
+    const [done, setDone] = useState(false);
 
     const router = useRouter();
-    const url = "http://localhost:8080"
+    const searchParams = useSearchParams();
+
+    const result: Result = {
+        score: searchParams.get("score") || "0",
+        accuracy: searchParams.get("accuracy") || "0.0",
+        correct: searchParams.get("correct") || "0",
+        total: searchParams.get("total") || "0",
+    };
 
     useEffect(() => {
-        const fetchResult = async () => {
-            try {
-                const res = await fetch(`${url}/api/single-results`, {
-                    method: "GET",
-                    headers: { 'Content-Type': 'application/json' },
-                })
-                const data: Result = await res.json()
-                setResult(data)
-            } catch {
-                setResult({ userid: 1, score: 100, accuracy_rate: 80 })
-            }
-        }
-        fetchResult()
-    }, [])
+        const correct = parseInt(result.correct);
+        const total = parseInt(result.total);
+        const miss = total - correct;
 
-    useEffect(() => {
-        if (!result) return;
-
-        const fullText = `結果\nスコア：${result.score}\n正答率：${result.accuracy_rate}%\n入力文字数:\nミス数:`;
+        const fullText = `結果\nスコア：${result.score}\n正答率：${result.accuracy}%\n入力文字数: ${result.total}\nミス数: ${miss > 0 ? miss : 0}`;
         let index = 0;
         setDisplayedText("");
         setDone(false);
@@ -53,33 +45,41 @@ export default function SingleResult() {
         }, 50);
 
         return () => clearInterval(timer);
-    }, [result])
+    }, [result.score, result.accuracy, result.correct, result.total]);
 
-    return(
-        <>
-           <WindowPanel>
-                <pre className="whitespace-pre-wrap font-[inherit]">
-                    {displayedText}
-                </pre>
-                {done && (
-                    <>
-                        <button
-                            type="button"
-                            onClick={() => router.push('/')}
-                            className="mt-8 self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
-                        >
-                            ▶ 再挑戦
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => router.push('/home')}
-                            className="mt-8 self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
-                        >
-                            ▶ home
-                        </button>
-                    </>
-                )}
-           </WindowPanel>
-        </>
-    )
+    return (
+        <WindowPanel>
+            <pre className="whitespace-pre-wrap font-[inherit] text-left text-xl leading-relaxed">
+                {displayedText}
+            </pre>
+            {done && (
+                <div className="flex gap-4 mt-8">
+                    <button
+                        type="button"
+                        onClick={() => router.push('/single')}
+                        className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+                    >
+                        ▶ 再挑戦
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => router.push('/home')}
+                        className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+                    >
+                        ▶ home
+                    </button>
+                </div>
+            )}
+        </WindowPanel>
+    );
+}
+
+export default function SingleResult() {
+    return (
+        <main className="flex flex-1 items-center justify-center p-4">
+            <Suspense fallback={<WindowPanel><p className="text-white">読み込み中...</p></WindowPanel>}>
+                <SingleResultContent />
+            </Suspense>
+        </main>
+    );
 }

--- a/src/app/result/SingleResult/page.tsx
+++ b/src/app/result/SingleResult/page.tsx
@@ -1,85 +1,89 @@
 "use client";
-import BackButton from "@/components/BackButton";
+
 import WindowPanel from "@/components/WindowPanel";
 import { useEffect, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 function SingleResultContent() {
-    interface Result {
-        score: string;
-        accuracy: string;
-        correct: string;
-        total: string;
-    }
+  interface Result {
+    score: string;
+    accuracy: string;
+    correct: string;
+    total: string;
+  }
 
-    const [displayedText, setDisplayedText] = useState("");
-    const [done, setDone] = useState(false);
+  const [displayedText, setDisplayedText] = useState("");
+  const [done, setDone] = useState(false);
 
-    const router = useRouter();
-    const searchParams = useSearchParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
-    const result: Result = {
-        score: searchParams.get("score") || "0",
-        accuracy: searchParams.get("accuracy") || "0.0",
-        correct: searchParams.get("correct") || "0",
-        total: searchParams.get("total") || "0",
-    };
+  const result: Result = {
+    score: searchParams.get("score") || "0",
+    accuracy: searchParams.get("accuracy") || "0.0",
+    correct: searchParams.get("correct") || "0",
+    total: searchParams.get("total") || "0",
+  };
 
-    useEffect(() => {
-        const correct = parseInt(result.correct);
-        const total = parseInt(result.total);
-        const miss = total - correct;
+  useEffect(() => {
+    const correct = parseInt(result.correct);
+    const total = parseInt(result.total);
+    const miss = total - correct;
 
-        const fullText = `結果\nスコア：${result.score}\n正答率：${result.accuracy}%\n入力文字数: ${result.total}\nミス数: ${miss > 0 ? miss : 0}`;
-        let index = 0;
-        setDisplayedText("");
-        setDone(false);
+    const fullText = `結果\nスコア：${result.score}\n正答率：${result.accuracy}%\n入力文字数: ${result.total}\nミス数: ${miss > 0 ? miss : 0}`;
+    let index = 0;
 
-        const timer = setInterval(() => {
-            index++;
-            setDisplayedText(fullText.slice(0, index));
-            if (index >= fullText.length) {
-                clearInterval(timer);
-                setDone(true);
-            }
-        }, 50);
+    const timer = setInterval(() => {
+      index++;
+      setDisplayedText(fullText.slice(0, index));
+      if (index >= fullText.length) {
+        clearInterval(timer);
+        setDone(true);
+      }
+    }, 50);
 
-        return () => clearInterval(timer);
-    }, [result.score, result.accuracy, result.correct, result.total]);
+    return () => clearInterval(timer);
+  }, [result.score, result.accuracy, result.correct, result.total]);
 
-    return (
-        <WindowPanel>
-            <pre className="whitespace-pre-wrap font-[inherit] text-left text-xl leading-relaxed">
-                {displayedText}
-            </pre>
-            {done && (
-                <div className="flex gap-4 mt-8">
-                    <button
-                        type="button"
-                        onClick={() => router.push('/single')}
-                        className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
-                    >
-                        ▶ 再挑戦
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => router.push('/home')}
-                        className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
-                    >
-                        ▶ home
-                    </button>
-                </div>
-            )}
-        </WindowPanel>
-    );
+  return (
+    <WindowPanel>
+      <pre className="whitespace-pre-wrap font-[inherit] text-left text-xl leading-relaxed">
+        {displayedText}
+      </pre>
+      {done && (
+        <div className="flex gap-4 mt-8">
+          <button
+            type="button"
+            onClick={() => router.push("/single")}
+            className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+          >
+            ▶ 再挑戦
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push("/home")}
+            className="self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+          >
+            ▶ home
+          </button>
+        </div>
+      )}
+    </WindowPanel>
+  );
 }
 
 export default function SingleResult() {
-    return (
-        <main className="flex flex-1 items-center justify-center p-4">
-            <Suspense fallback={<WindowPanel><p className="text-white">読み込み中...</p></WindowPanel>}>
-                <SingleResultContent />
-            </Suspense>
-        </main>
-    );
+  return (
+    <main className="flex flex-1 items-center justify-center p-4">
+      <Suspense
+        fallback={
+          <WindowPanel>
+            <p className="text-white">読み込み中...</p>
+          </WindowPanel>
+        }
+      >
+        <SingleResultContent />
+      </Suspense>
+    </main>
+  );
 }

--- a/src/app/single/page.tsx
+++ b/src/app/single/page.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import WindowPanel from "@/components/WindowPanel";
+import BackButton from "@/components/BackButton";
+
+interface Word {
+  id: number;
+  displayText: string;
+  kanaReading: string;
+  romajiTarget: string;
+}
+
+export default function SingleModePage() {
+  const router = useRouter();
+
+  // --- ステート管理 (主にUI表示用) ---
+  const [words, setWords] = useState<Word[]>([]);
+  const [currentWord, setCurrentWord] = useState<Word | null>(null);
+  const [userInput, setUserInput] = useState("");
+  const [isStarted, setIsStarted] = useState(false);
+  const [isFinished, setIsFinished] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // --- スコア・統計関連 ---
+  const [timeLeft, setTimeLeft] = useState(60);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [totalInput, setTotalInput] = useState(0);
+  const [displayScore, setDisplayScore] = useState(0);
+
+  // --- ロジック同期用 Ref ---
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const userInputRef = useRef("");
+  const correctCountRef = useRef(0);
+  const totalInputRef = useRef(0);
+
+  // --- 全角英数を半角に変換する正規化関数 ---
+  const normalizeInput = (value: string) => {
+    return value
+      .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (char) =>
+        String.fromCharCode(char.charCodeAt(0) - 0xfee0)
+      )
+      .replace(/[ー]/g, "-")
+      .replace(/[^a-zA-Z0-9-]/g, "");
+  };
+
+  // --- 1. ワード全件取得 ---
+  useEffect(() => {
+    const fetchWords = async () => {
+      try {
+        const response = await fetch("http://localhost:8080/api/words");
+        if (!response.ok) throw new Error("Fetch failed");
+        const data = await response.json();
+        setWords(data);
+      } catch (error) {
+        console.error("ワードの取得に失敗しました:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchWords();
+  }, []);
+
+  // --- 2. ワードのランダム選択 ---
+  const setNextWord = useCallback(() => {
+    if (words.length > 0) {
+      const randomIndex = Math.floor(Math.random() * words.length);
+      setCurrentWord(words[randomIndex]);
+      setUserInput("");
+      userInputRef.current = ""; // 同期
+    }
+  }, [words]);
+
+  // --- 3. ゲーム開始 ---
+  const start = useCallback(() => {
+    if (isLoading || words.length === 0) return;
+    
+    // 値のリセット
+    setIsStarted(true);
+    setIsFinished(false);
+    setTimeLeft(60);
+    setCorrectCount(0);
+    setTotalInput(0);
+    setDisplayScore(0);
+    
+    correctCountRef.current = 0;
+    totalInputRef.current = 0;
+    userInputRef.current = "";
+    
+    setNextWord();
+    
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, [setNextWord, isLoading, words.length]);
+
+  // エンターキーで開始
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if (!isStarted && !isFinished && e.key === "Enter") {
+        start();
+      }
+    };
+    window.addEventListener("keydown", handleGlobalKeyDown);
+    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
+  }, [isStarted, isFinished, start]);
+
+  // --- 4. スコア計算ロジック ---
+  const calculateCurrentScore = (correct: number, total: number) => {
+    if (total === 0) return 0;
+    const accuracy = correct / total;
+    return Math.ceil(correct * accuracy);
+  };
+
+  // --- 5. 入力判定ロジック (KeyDown方式) ---
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isStarted || isFinished || !currentWord) return;
+
+    // 1文字の入力のみ処理（特殊キーなどは無視）
+    if (e.key.length !== 1) return;
+
+    const char = normalizeInput(e.key.toLowerCase());
+    if (!char) return;
+
+    const target = currentWord.romajiTarget;
+    const nextInput = userInputRef.current + char;
+
+    // 入力総数を更新
+    totalInputRef.current += 1;
+    const currentTotal = totalInputRef.current;
+    setTotalInput(currentTotal);
+
+    if (target.startsWith(nextInput)) {
+      // 正解
+      userInputRef.current = nextInput;
+      setUserInput(nextInput);
+      
+      correctCountRef.current += 1;
+      const currentCorrect = correctCountRef.current;
+      setCorrectCount(currentCorrect);
+      
+      const newScore = calculateCurrentScore(currentCorrect, currentTotal);
+      setDisplayScore(newScore);
+
+      if (nextInput === target) {
+        // 少しディレイを置いて次のワードへ（打ち切った感のため）
+        setTimeout(setNextWord, 50);
+      }
+    } else {
+      // ミス
+      const newScore = calculateCurrentScore(correctCountRef.current, currentTotal);
+      setDisplayScore(newScore);
+    }
+  };
+
+  // --- 6. ゲーム終了処理 ---
+  const handleGameEnd = useCallback(() => {
+    setIsFinished(true);
+    if (timerRef.current) clearInterval(timerRef.current);
+  }, []);
+
+  // 終了時のデータ保存
+  useEffect(() => {
+    if (isFinished) {
+      const saveResult = async () => {
+        const finalCorrect = correctCountRef.current;
+        const finalTotal = totalInputRef.current;
+        const finalScore = calculateCurrentScore(finalCorrect, finalTotal);
+
+        try {
+          await fetch("http://localhost:8080/api/single-results", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              userId: 1,
+              rawScore: finalCorrect,
+              correctCount: finalCorrect,
+              totalInput: finalTotal,
+            }),
+          });
+        } catch (error) {
+          console.error("スコアの保存に失敗しました:", error);
+        }
+
+        const accuracy = finalTotal > 0 ? ((finalCorrect / finalTotal) * 100).toFixed(1) : "0.0";
+        router.push(`/result/SingleResult?score=${finalScore}&accuracy=${accuracy}&correct=${finalCorrect}&total=${finalTotal}`);
+      };
+      saveResult();
+    }
+  }, [isFinished, router]);
+
+  // --- 7. タイマー管理 ---
+  useEffect(() => {
+    if (isStarted && !isFinished) {
+      timerRef.current = setInterval(() => {
+        setTimeLeft((prev) => {
+          if (prev <= 1) {
+            handleGameEnd();
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [isStarted, isFinished, handleGameEnd]);
+
+  // フォーカス維持
+  useEffect(() => {
+    if (isStarted && !isFinished) {
+      const focusInterval = setInterval(() => {
+        if (document.activeElement !== inputRef.current) {
+          inputRef.current?.focus();
+        }
+      }, 500);
+      return () => clearInterval(focusInterval);
+    }
+  }, [isStarted, isFinished]);
+
+  return (
+    <main className="flex flex-1 items-center justify-center p-4">
+      <WindowPanel>
+        <div className="flex w-full flex-col items-center">
+          <div className="mb-8 flex w-full items-center justify-between">
+            <BackButton />
+            <div className="text-2xl font-bold tracking-tighter">SINGLE MODE</div>
+            <div className="w-12"></div>
+          </div>
+
+          {isLoading ? (
+            <div className="py-20 text-slate-400">LOADING WORDS...</div>
+          ) : !isStarted ? (
+            <div className="flex flex-col items-center py-20">
+              <button
+                onClick={start}
+                className="group relative flex items-center gap-2 text-4xl font-bold italic transition-all hover:scale-110"
+              >
+                <span className="text-slate-800">PRESS ENTER TO START</span>
+                <span className="animate-ping absolute -right-4 -top-1 inline-flex h-3 w-3 rounded-full bg-blue-400 opacity-75"></span>
+              </button>
+            </div>
+          ) : (
+            <div className="flex w-full flex-col items-center">
+              <div className="mb-10 grid w-full grid-cols-3 gap-4 border-b pb-4">
+                <div className="flex flex-col">
+                  <span className="text-xs text-slate-400">TIME</span>
+                  <span className={`text-2xl font-mono ${timeLeft <= 10 ? "text-red-500 animate-pulse" : ""}`}>
+                    {timeLeft}s
+                  </span>
+                </div>
+                <div className="flex flex-col items-center border-x">
+                  <span className="text-xs text-slate-400">SCORE</span>
+                  <span className="text-2xl font-mono">{displayScore}</span>
+                </div>
+                <div className="flex flex-col items-end">
+                  <span className="text-xs text-slate-400">ACCURACY</span>
+                  <span className="text-2xl font-mono">
+                    {totalInput > 0 ? ((correctCount / totalInput) * 100).toFixed(1) : "0.0"}%
+                  </span>
+                </div>
+              </div>
+
+              <div className="relative flex flex-col items-center py-10 w-full min-h-[240px]">
+                {currentWord && (
+                  <>
+                    <div className="text-xl text-slate-400">{currentWord.kanaReading}</div>
+                    <div className="mt-2 text-5xl font-bold tracking-widest text-slate-800">
+                      {currentWord.displayText}
+                    </div>
+                    <div className="mt-8 text-3xl font-mono tracking-wider">
+                      <span className="text-blue-500 underline decoration-2 underline-offset-8">
+                        {userInput}
+                      </span>
+                      <span className="text-slate-200">
+                        {currentWord.romajiTarget.slice(userInput.length)}
+                      </span>
+                    </div>
+                  </>
+                )}
+                <input
+                  ref={inputRef}
+                  autoFocus
+                  type="text"
+                  onKeyDown={handleKeyDown}
+                  value="" // valueを固定してもKeyDownイベントは取れる
+                  readOnly // 読み取り専用にすることでIMEの介入を最小限にする
+                  inputMode="url"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="absolute inset-0 h-full w-full cursor-default bg-transparent opacity-0 outline-none"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </WindowPanel>
+    </main>
+  );
+}

--- a/src/app/single/page.tsx
+++ b/src/app/single/page.tsx
@@ -237,7 +237,7 @@ export default function SingleModePage() {
                 onClick={start}
                 className="group relative flex items-center gap-2 text-4xl font-bold italic transition-all hover:scale-110"
               >
-                <span className="text-slate-800">PRESS ENTER TO START</span>
+                <span className="text-white">PRESS ENTER TO START</span>
                 <span className="animate-ping absolute -right-4 -top-1 inline-flex h-3 w-3 rounded-full bg-blue-400 opacity-75"></span>
               </button>
             </div>
@@ -266,7 +266,7 @@ export default function SingleModePage() {
                 {currentWord && (
                   <>
                     <div className="text-xl text-slate-400">{currentWord.kanaReading}</div>
-                    <div className="mt-2 text-5xl font-bold tracking-widest text-slate-800">
+                    <div className="mt-2 text-5xl font-bold tracking-widest text-white">
                       {currentWord.displayText}
                     </div>
                     <div className="mt-8 text-3xl font-mono tracking-wider">

--- a/src/app/single/page.tsx
+++ b/src/app/single/page.tsx
@@ -17,6 +17,7 @@ export default function SingleModePage() {
 
   // --- ステート管理 (主にUI表示用) ---
   const [words, setWords] = useState<Word[]>([]);
+  const [wordPool, setWordPool] = useState<Word[]>([]); // まだ出題していない単語の山札
   const [currentWord, setCurrentWord] = useState<Word | null>(null);
   const [userInput, setUserInput] = useState("");
   const [isStarted, setIsStarted] = useState(false);
@@ -40,7 +41,7 @@ export default function SingleModePage() {
   const normalizeInput = (value: string) => {
     return value
       .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (char) =>
-        String.fromCharCode(char.charCodeAt(0) - 0xfee0)
+        String.fromCharCode(char.charCodeAt(0) - 0xfee0),
       )
       .replace(/[ー]/g, "-")
       .replace(/[^a-zA-Z0-9-]/g, "");
@@ -65,18 +66,31 @@ export default function SingleModePage() {
 
   // --- 2. ワードのランダム選択 ---
   const setNextWord = useCallback(() => {
-    if (words.length > 0) {
-      const randomIndex = Math.floor(Math.random() * words.length);
-      setCurrentWord(words[randomIndex]);
+    if (words.length === 0) return;
+
+    setWordPool((prevPool) => {
+      let currentPool = [...prevPool];
+
+      // もし空になったら補充してシャッフル
+      if (currentPool.length === 0) {
+        currentPool = [...words].sort(() => Math.random() - 0.5);
+      }
+
+      // 単語リストの最後から1つ取り出す
+      const nextWord = currentPool.pop()!;
+
+      setCurrentWord(nextWord);
       setUserInput("");
       userInputRef.current = ""; // 同期
-    }
+
+      return currentPool;
+    });
   }, [words]);
 
   // --- 3. ゲーム開始 ---
   const start = useCallback(() => {
     if (isLoading || words.length === 0) return;
-    
+
     // 値のリセット
     setIsStarted(true);
     setIsFinished(false);
@@ -84,15 +98,21 @@ export default function SingleModePage() {
     setCorrectCount(0);
     setTotalInput(0);
     setDisplayScore(0);
-    
+    setWordPool([]); // 山札をリセット（新しいゲームごとにシャッフルされるように）
+
     correctCountRef.current = 0;
     totalInputRef.current = 0;
     userInputRef.current = "";
-    
-    setNextWord();
-    
+
+    // 初回の単語セット
+    // setWordPoolの非同期処理を待たずにwordsから直接初回分をセットする工夫
+    const initialPool = [...words].sort(() => Math.random() - 0.5);
+    const firstWord = initialPool.pop()!;
+    setCurrentWord(firstWord);
+    setWordPool(initialPool);
+
     setTimeout(() => inputRef.current?.focus(), 0);
-  }, [setNextWord, isLoading, words.length]);
+  }, [isLoading, words]);
 
   // エンターキーで開始
   useEffect(() => {
@@ -134,11 +154,11 @@ export default function SingleModePage() {
       // 正解
       userInputRef.current = nextInput;
       setUserInput(nextInput);
-      
+
       correctCountRef.current += 1;
       const currentCorrect = correctCountRef.current;
       setCorrectCount(currentCorrect);
-      
+
       const newScore = calculateCurrentScore(currentCorrect, currentTotal);
       setDisplayScore(newScore);
 
@@ -148,7 +168,10 @@ export default function SingleModePage() {
       }
     } else {
       // ミス
-      const newScore = calculateCurrentScore(correctCountRef.current, currentTotal);
+      const newScore = calculateCurrentScore(
+        correctCountRef.current,
+        currentTotal,
+      );
       setDisplayScore(newScore);
     }
   };
@@ -182,8 +205,13 @@ export default function SingleModePage() {
           console.error("スコアの保存に失敗しました:", error);
         }
 
-        const accuracy = finalTotal > 0 ? ((finalCorrect / finalTotal) * 100).toFixed(1) : "0.0";
-        router.push(`/result/SingleResult?score=${finalScore}&accuracy=${accuracy}&correct=${finalCorrect}&total=${finalTotal}`);
+        const accuracy =
+          finalTotal > 0
+            ? ((finalCorrect / finalTotal) * 100).toFixed(1)
+            : "0.0";
+        router.push(
+          `/result/SingleResult?score=${finalScore}&accuracy=${accuracy}&correct=${finalCorrect}&total=${finalTotal}`,
+        );
       };
       saveResult();
     }
@@ -225,7 +253,9 @@ export default function SingleModePage() {
         <div className="flex w-full flex-col items-center">
           <div className="mb-8 flex w-full items-center justify-between">
             <BackButton />
-            <div className="text-2xl font-bold tracking-tighter">SINGLE MODE</div>
+            <div className="text-2xl font-bold tracking-tighter">
+              SINGLE MODE
+            </div>
             <div className="w-12"></div>
           </div>
 
@@ -238,7 +268,6 @@ export default function SingleModePage() {
                 className="group relative flex items-center gap-2 text-4xl font-bold italic transition-all hover:scale-110"
               >
                 <span className="text-white">PRESS ENTER TO START</span>
-                <span className="animate-ping absolute -right-4 -top-1 inline-flex h-3 w-3 rounded-full bg-blue-400 opacity-75"></span>
               </button>
             </div>
           ) : (
@@ -246,7 +275,9 @@ export default function SingleModePage() {
               <div className="mb-10 grid w-full grid-cols-3 gap-4 border-b pb-4">
                 <div className="flex flex-col">
                   <span className="text-xs text-slate-400">TIME</span>
-                  <span className={`text-2xl font-mono ${timeLeft <= 10 ? "text-red-500 animate-pulse" : ""}`}>
+                  <span
+                    className={`text-2xl font-mono ${timeLeft <= 10 ? "text-red-500 animate-pulse" : ""}`}
+                  >
                     {timeLeft}s
                   </span>
                 </div>
@@ -257,7 +288,10 @@ export default function SingleModePage() {
                 <div className="flex flex-col items-end">
                   <span className="text-xs text-slate-400">ACCURACY</span>
                   <span className="text-2xl font-mono">
-                    {totalInput > 0 ? ((correctCount / totalInput) * 100).toFixed(1) : "0.0"}%
+                    {totalInput > 0
+                      ? ((correctCount / totalInput) * 100).toFixed(1)
+                      : "0.0"}
+                    %
                   </span>
                 </div>
               </div>
@@ -265,7 +299,9 @@ export default function SingleModePage() {
               <div className="relative flex flex-col items-center py-10 w-full min-h-[240px]">
                 {currentWord && (
                   <>
-                    <div className="text-xl text-slate-400">{currentWord.kanaReading}</div>
+                    <div className="text-xl text-slate-400">
+                      {currentWord.kanaReading}
+                    </div>
                     <div className="mt-2 text-5xl font-bold tracking-widest text-white">
                       {currentWord.displayText}
                     </div>


### PR DESCRIPTION
     #シングルモード（タイピング練習機能）のフロントエンド実装
    
   ## 📝 概要
     一人でタイピング練習ができる「シングルモード」のフロントエンド機能を実装しました。
     ワードの取得から、リアルタイムのタイピング判定、スコア保存、結果表示までの一連のサイクルが含まれます。
    
     ## ✨ 実装内容
    
     ### 1. ゲームメイン画面 (`/single`)
    *   **ワード自動取得**: バックエンドAPI (`/api/words`) から練習用ワードをランダムに取得。
    *   **タイピングロジック**:
        *   `KeyDown` イベントによる高速・正確な入力判定。
        *   全角英数の半角自動変換、およびローマ字ガイドのリアルタイム色分け表示。
        *   60秒の制限時間管理（残り10秒で警告アニメーション）。
    *   **スコア計算**: 正解数 × 正解率に基づいたスコア算出。
   
    ### 2. 結果表示画面 (`/result/SingleResult`)
    *   **タイプライター演出**: 最終結果（スコア、正解率、入力数、ミス数）をアニメーションで表示。
    *   **リプレイ機能**: 「再挑戦」ボタンで即座にゲームをやり直せる動線を確保。
   
    ### 3. データ連携
    *   **自動保存**: ゲーム終了時にスコアをバックエンド (`/api/single-results`) へPOST送信。
    *   **ナビゲーション**: ホーム画面からシングルモードへのリンクを接続。
   
    ## 🛠 変更ファイル
    - `src/app/single/page.tsx`: ゲームメインロジックとUI
    - `src/app/result/SingleResult/page.tsx`: 結果表示画面とアニメーション
    - `src/app/home/page.tsx`: シングルモードへのパスを追加
    - `package-lock.json`: 依存関係のメタデータ更新（npmによる自動更新）
   
    ## 💡 技術的な工夫
    *   **入力体験の向上**: IMEの干渉を抑えるため、非表示の `input` 要素を `readOnly` かつ `inputMode="url"` で制御し、直接キー入力を捕捉する方式を採用しました。
    *   **UIの一貫性**: 既存の `WindowPanel` コンポーネントを再利用し、ゲームの世界観を統一しました。