### PR TITLE
ユーザー登録画面の作成

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import WindowPanel from "@/components/WindowPanel";
+
+type FormErrors = {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  verificationCode?: string;
+  general?: string;
+};
+
+const API_BASE = "http://localhost:8080";
+
+function validateRegister(
+  name: string,
+  email: string,
+  password: string,
+  confirmPassword: string,
+): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!name) {
+    errors.name = "ユーザー名を入力してください";
+  }
+
+  if (!email) {
+    errors.email = "メールアドレスを入力してください";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.email = "メールアドレスの形式が正しくありません";
+  }
+
+  if (!password) {
+    errors.password = "パスワードを入力してください";
+  } else if (password.length < 8 || password.length > 127) {
+    errors.password = "パスワードは8文字以上、127文字以内で入力してください";
+  }
+
+  if (!confirmPassword) {
+    errors.confirmPassword = "確認用パスワードを入力してください";
+  } else if (password !== confirmPassword) {
+    errors.confirmPassword = "パスワードが一致しません";
+  }
+
+  return errors;
+}
+
+function validateCode(code: string): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!code) {
+    errors.verificationCode = "認証コードを入力してください";
+  }
+
+  return errors;
+}
+
+export default function RegisterPage() {
+  const router = useRouter();
+
+  const [step, setStep] = useState<"register" | "verify">("register");
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
+
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleRegister(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const validationErrors = validateRegister(name, email, password, confirmPassword);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const res = await fetch(`${API_BASE}/api/users/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ name, email, password }),
+      });
+
+      if (!res.ok) {
+        const data: { message?: string } = await res.json().catch(() => ({}));
+
+        if (res.status === 409) {
+          setErrors({
+            general: "このメールアドレスは既に登録されています。",
+          });
+          return;
+        }
+
+        setErrors({
+          general: data.message ?? "ユーザー登録に失敗しました",
+        });
+
+        return;
+      }
+
+      // 二段階認証API（/api/auth/verify-code）未実装のため、
+      // 登録成功後にログイン画面へ遷移する。
+      // setStep("verify");
+      router.push("/login");
+    } catch {
+      setErrors({ general: "通信エラーが発生しました" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleVerify(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const validationErrors = validateCode(verificationCode);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/verify-code`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email, code: verificationCode }),
+      });
+
+      if (!res.ok) {
+        const data: { message?: string } = await res.json().catch(() => ({}));
+        setErrors({ general: data.message ?? "認証コードが正しくありません" });
+        return;
+      }
+
+      router.push("/login");
+    } catch {
+      setErrors({ general: "通信エラーが発生しました" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="flex flex-1 items-center justify-center overflow-auto">
+      <div className="[&>section]:min-h-[500px] [&>section]:min-w-[600px]">
+        <WindowPanel>
+          <h1 className="text-3xl font-bold tracking-wide text-white">
+            新規登録
+          </h1>
+
+          {step === "register" ? (
+            <form
+              onSubmit={handleRegister}
+              noValidate
+              className="mt-6 flex w-full max-w-sm flex-col gap-5"
+            >
+              {/* 通信エラー */}
+              <p
+                role={errors.general ? "alert" : undefined}
+                className={`min-h-[25px] -mt-3 text-left text-base ${errors.general ? "text-red-400" : "text-transparent"}`}
+              >
+                {errors.general ?? "\u00A0"}
+              </p>
+
+              {/* ユーザー名 */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="name"
+                  role={errors.name ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.name ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.name ?? "ユーザー名"}
+                </label>
+                <input
+                  id="name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  autoComplete="username"
+                  placeholder="山田 太郎"
+                  className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+              </div>
+
+              {/* メールアドレス */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="email"
+                  role={errors.email ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.email ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.email ?? "メールアドレス"}
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="email"
+                  placeholder="*****@outlook.jp"
+                  className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+              </div>
+
+              {/* パスワード */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="password"
+                  role={errors.password ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.password ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.password ?? "パスワード"}
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete="new-password"
+                  placeholder="8文字以上、127文字以内"
+                  className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+              </div>
+
+              {/* パスワード（確認用） */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="confirmPassword"
+                  role={errors.confirmPassword ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.confirmPassword ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.confirmPassword ?? "パスワード（確認用）"}
+                </label>
+                <input
+                  id="confirmPassword"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
+                  placeholder="パスワードを再入力してください"
+                  className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+              </div>
+
+              {/* 登録ボタン */}
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="mt-1 border border-slate-400 bg-[#0d1b3e]/60 py-2 text-lg font-bold tracking-[0.03em] text-white hover:border-yellow-200 hover:text-yellow-200 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? "読み込み中..." : "登録する"}
+              </button>
+
+              <p className="text-center text-sm text-slate-300">
+                すでにアカウントをお持ちの方は{" "}
+                <a href="/login">
+                  <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
+                    ログイン
+                  </span>
+                </a>
+              </p>
+            </form>
+          ) : (
+            <form
+              onSubmit={handleVerify}
+              noValidate
+              className="mt-6 flex w-full max-w-sm flex-col gap-5"
+            >
+              {/* 案内文 / 通信エラー */}
+              <p
+                role={errors.general ? "alert" : undefined}
+                className={`whitespace-nowrap text-left text-sm ${errors.general ? "text-red-400" : "text-slate-300"
+                  }`}
+              >
+                {errors.general ?? "メールアドレスに送信された認証コードを入力してください。"}
+              </p>
+
+              {/* 認証コード */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="verificationCode"
+                  role={errors.verificationCode ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.verificationCode ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.verificationCode ?? "認証コード"}
+                </label>
+                <input
+                  id="verificationCode"
+                  type="text"
+                  value={verificationCode}
+                  onChange={(e) => setVerificationCode(e.target.value)}
+                  placeholder="認証コードを入力"
+                  className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="mt-1 border border-slate-400 bg-[#0d1b3e]/60 py-2 text-lg font-bold tracking-[0.03em] text-white hover:border-yellow-200 hover:text-yellow-200 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? "読み込み中..." : "認証する"}
+              </button>
+            </form>
+          )}
+        </WindowPanel>
+      </div>
+    </main>
+  );
+}

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -11,7 +11,7 @@ export default function BackButton() {
       onClick={() => router.back()}
       className="mt-8 self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
     >
-      ▶ 戻る
+      ◀ 戻る
     </button>
   );
 }


### PR DESCRIPTION
# 概要
ユーザー登録画面を実装しました。
登録APIと連携し、メールアドレス・パスワードによる新規アカウント作成ができるようになります。

---

# 実装した画面

| 画面名 | URL |
|---|---|
| ユーザー登録画面 | `/register` |

---

# 主な変更内容

## 1. ユーザー登録画面

### 表示内容
- ユーザー名・メールアドレス・パスワード・パスワード（確認用）の入力フォーム
- 登録済みアカウントへのログインリンク

### バリデーション

| 項目 | 内容 |
|---|---|
| ユーザー名 | 必須 |
| メールアドレス | 必須・形式チェック |
| パスワード | 必須・8文字以上127文字以内 |
| パスワード（確認用） | 必須・パスワードと一致チェック |

### エラー制御
- 未入力・形式不正はフィールドラベルがエラーメッセージに切り替わる形式で表示
- メールアドレス重複（409）時は専用エラーメッセージを表示
- APIエラー時はエラーメッセージを表示
- 通信エラー時はエラーメッセージを表示

---

# 確認方法
## アプリケーション起動

```bash
# バックエンド
mvn spring-boot:run
# フロントエンド
npm run dev
```

## 動作確認
1. `http://localhost:3000/register` にアクセス
2. 各フィールドを未入力で送信し、バリデーションエラーが表示されること
3. 不正なメールアドレス形式でエラーが表示されること
4. パスワードが8文字未満・128文字以上でエラーが表示されること
5. パスワードと確認用パスワードが不一致でエラーが表示されること
6. 登録済みのメールアドレスで登録した場合、「このメールアドレスは既に登録されています。」とエラーメッセージが表示されること
7. 正常に登録するとログイン画面へ遷移すること

---

# 仕様確認状況
- 各フィールドのバリデーションが正しく動作すること
- メールアドレス重複時に適切なエラーメッセージが表示されること
- APIエラー・通信エラー時に適切なメッセージが表示されること
- 登録成功後にログイン画面へ遷移すること