### PR TITLE
アカウント設定画面のAPI連携を実装

### DIFF
--- a/src/app/account-settings/delete/page.tsx
+++ b/src/app/account-settings/delete/page.tsx
@@ -16,7 +16,11 @@ type DeleteCommand = Readonly<{
 }>;
 
 async function deleteAccount(): Promise<void> {
-  const response = await fetchWithAuth("/api/users/me", {
+  const userId = localStorage.getItem("userId");
+  if (!userId) {
+    throw new Error("ユーザー情報が取得できませんでした");
+  }
+  const response = await fetchWithAuth(`/api/users/${userId}`, {
     method: "DELETE",
   });
 

--- a/src/app/account-settings/delete/page.tsx
+++ b/src/app/account-settings/delete/page.tsx
@@ -7,14 +7,26 @@ import MessagePanel from "@/components/MessagePanel";
 import TypewriterText from "@/components/TypewriterText";
 import WindowPanel from "@/components/WindowPanel";
 
-type DeleteStep = "first" | "final" | "done";
+import { fetchWithAuth } from "@/lib/fetchWithAuth";
+
+type DeleteStep = "first" | "final" | "done" | "error";
 type DeleteCommand = Readonly<{
   label: string;
   action: () => Promise<void> | void;
 }>;
 
-async function deleteAccount() {
-  console.log("TODO: DELETE /api/users/:userId");
+async function deleteAccount(): Promise<void> {
+  const response = await fetchWithAuth("/api/users/me", {
+    method: "DELETE",
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const message = data.message
+      ? data.message.replace(/\s*ID:\s*\d+/g, "")
+      : `削除に失敗しました（${response.status}）`;
+    throw new Error(message);
+  }
 }
 
 const doneMessagePrefix = "ぼうけんのしょは\nきえてしまいました\n\n";
@@ -23,6 +35,7 @@ const messageByStep = {
   first: "アカウントを けしますか？\n\nこのそうさは\nもとに もどせません。",
   final: "……\n\nほんとうに けしますか？",
   done: `${doneMessagePrefix}(^_−)☆`,
+  error: "",
 } as const;
 
 const pausesByStep: Readonly<Partial<Record<DeleteStep, Record<number, number>>>> = {
@@ -39,6 +52,9 @@ export default function DeleteAccountPage() {
   const [step, setStep] = useState<DeleteStep>("first");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const currentMessage = step === "error" ? errorMessage : messageByStep[step];
 
   const commands = useMemo<DeleteCommand[]>(() => {
     if (step === "first") {
@@ -61,10 +77,33 @@ export default function DeleteAccountPage() {
           label: "はい",
           action: async () => {
             setIsDeleting(true);
-            await deleteAccount();
+            try {
+              await deleteAccount();
+              setSelectedIndex(0);
+              setStep("done");
+            } catch (error) {
+              const message =
+                error instanceof Error && error.message !== "Failed to fetch"
+                  ? error.message
+                  : "通信エラーが はっせいしました";
+              setErrorMessage(`さくじょに\nしっぱいしました\n\n${message}`);
+              setSelectedIndex(0);
+              setStep("error");
+            } finally {
+              setIsDeleting(false);
+            }
+          },
+        },
+      ];
+    }
+
+    if (step === "error") {
+      return [
+        {
+          label: "もどる",
+          action: () => {
             setSelectedIndex(0);
-            setStep("done");
-            setIsDeleting(false);
+            setStep("first");
           },
         },
       ];
@@ -119,7 +158,7 @@ export default function DeleteAccountPage() {
           <MessagePanel className="h-72">
             <TypewriterText
               key={step}
-              text={messageByStep[step]}
+              text={currentMessage}
               speed={45}
               pauses={pausesByStep[step]}
             />
@@ -146,9 +185,8 @@ export default function DeleteAccountPage() {
                     key={command.label}
                     type="button"
                     disabled={isDeleting}
-                    className={`inline-flex self-start text-left transition-colors disabled:cursor-wait disabled:opacity-60 ${
-                      isSelected ? "text-yellow-200" : "text-white"
-                    }`}
+                    className={`inline-flex self-start text-left transition-colors disabled:cursor-wait disabled:opacity-60 ${isSelected ? "text-yellow-200" : "text-white"
+                      }`}
                     onMouseEnter={() => setSelectedIndex(index)}
                     onClick={() => {
                       runCommand(command).catch((error: unknown) => {

--- a/src/app/account-settings/email/page.tsx
+++ b/src/app/account-settings/email/page.tsx
@@ -4,14 +4,33 @@ import Link from "next/link";
 import { useState } from "react";
 
 import WindowPanel from "@/components/WindowPanel";
+import { fetchWithAuth } from "@/lib/fetchWithAuth";
 
-async function updateEmail(email: string) {
-  console.log("TODO: PATCH /api/users/:userId", { email });
+async function updateEmail(email: string): Promise<void> {
+  const userId = localStorage.getItem("userId");
+  if (!userId) {
+    throw new Error("ユーザー情報が取得できませんでした");
+  }
+  const response = await fetchWithAuth(`/api/users/${userId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const message = data.message
+      ? data.message.replace(/\s*ID:\s*\d+/g, "")
+      : `メール変更に失敗しました（${response.status}）`;
+    throw new Error(message);
+  }
 }
 
 export default function EmailSettingsPage() {
+  const [step, setStep] = useState<"email" | "verify">("email");
   const [email, setEmail] = useState("");
   const [confirmEmail, setConfirmEmail] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
   const [message, setMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -24,8 +43,46 @@ export default function EmailSettingsPage() {
       return;
     }
 
-    await updateEmail(email);
-    setMessage("メール変更の仮処理を実行しました");
+    try {
+      await updateEmail(email);
+      setStep("verify");
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "通信エラーが発生しました";
+      setErrorMessage(msg);
+    }
+  };
+
+  const handleVerify = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setMessage("");
+    setErrorMessage("");
+
+    if (!verificationCode) {
+      setErrorMessage("認証コードを入力してください");
+      return;
+    }
+
+    try {
+      const response = await fetchWithAuth("/api/auth/verify-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, code: verificationCode }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setErrorMessage(data.message ?? "認証コードが正しくありません");
+        return;
+      }
+
+      setMessage("メールアドレスを変更しました");
+      setStep("email");
+      setEmail("");
+      setConfirmEmail("");
+      setVerificationCode("");
+    } catch {
+      setErrorMessage("通信エラーが発生しました");
+    }
   };
 
   return (
@@ -35,46 +92,77 @@ export default function EmailSettingsPage() {
           メール変更
         </h1>
 
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-            handleSubmit().catch((error: unknown) => {
-              console.error(error);
-            });
-          }}
-          className="mt-8 flex w-full max-w-md flex-col gap-5 text-left"
-        >
-          <label className="flex flex-col gap-2">
-            <span className="text-yellow-200">新しいメールアドレス</span>
-            <input
-              type="email"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              className="border-2 border-white bg-[#050816] px-4 py-3 text-white outline-none focus:border-yellow-200"
-              placeholder="guest@example.com"
-              required
-            />
-          </label>
-
-          <label className="flex flex-col gap-2">
-            <span className="text-yellow-200">確認用メールアドレス</span>
-            <input
-              type="email"
-              value={confirmEmail}
-              onChange={(event) => setConfirmEmail(event.target.value)}
-              className="border-2 border-white bg-[#050816] px-4 py-3 text-white outline-none focus:border-yellow-200"
-              placeholder="guest@example.com"
-              required
-            />
-          </label>
-
-          <button
-            type="submit"
-            className="self-start border-2 border-white px-4 py-2 transition-colors hover:border-yellow-200 hover:text-yellow-200"
+        {step === "email" ? (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleSubmit().catch((error: unknown) => {
+                console.error(error);
+              });
+            }}
+            className="mt-8 flex w-full max-w-md flex-col gap-5 text-left"
           >
-            ▶ 変更する
-          </button>
-        </form>
+            <label className="flex flex-col gap-2">
+              <span className="text-yellow-200">新しいメールアドレス</span>
+              <input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="border-2 border-white bg-[#050816] px-4 py-3 text-white outline-none focus:border-yellow-200"
+                placeholder="guest@example.com"
+                required
+              />
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-yellow-200">確認用メールアドレス</span>
+              <input
+                type="email"
+                value={confirmEmail}
+                onChange={(event) => setConfirmEmail(event.target.value)}
+                className="border-2 border-white bg-[#050816] px-4 py-3 text-white outline-none focus:border-yellow-200"
+                placeholder="guest@example.com"
+                required
+              />
+            </label>
+
+            <button
+              type="submit"
+              className="self-start border-2 border-white px-4 py-2 transition-colors hover:border-yellow-200 hover:text-yellow-200"
+            >
+              ▶ 変更する
+            </button>
+          </form>
+        ) : (
+          <form
+            onSubmit={handleVerify}
+            noValidate
+            className="mt-8 flex w-full max-w-md flex-col gap-5 text-left"
+          >
+            <p className="text-sm text-slate-300">
+              メールアドレスに送信された認証コードを入力してください。
+            </p>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-yellow-200">認証コード</span>
+              <input
+                type="text"
+                value={verificationCode}
+                onChange={(event) => setVerificationCode(event.target.value)}
+                className="border-2 border-white bg-[#050816] px-4 py-3 text-white outline-none focus:border-yellow-200"
+                placeholder="認証コードを入力"
+                required
+              />
+            </label>
+
+            <button
+              type="submit"
+              className="self-start border-2 border-white px-4 py-2 transition-colors hover:border-yellow-200 hover:text-yellow-200"
+            >
+              ▶ 認証する
+            </button>
+          </form>
+        )}
 
         {message ? <p className="mt-4 text-yellow-200">{message}</p> : null}
         {errorMessage ? (

--- a/src/app/account-settings/password/page.tsx
+++ b/src/app/account-settings/password/page.tsx
@@ -4,12 +4,26 @@ import Link from "next/link";
 import { useState } from "react";
 
 import WindowPanel from "@/components/WindowPanel";
+import { fetchWithAuth } from "@/lib/fetchWithAuth";
 
-async function updatePassword(currentPassword: string, newPassword: string) {
-  console.log("TODO: PATCH /api/users/:userId", {
-    currentPassword,
-    newPassword,
+async function updatePassword(currentPassword: string, newPassword: string): Promise<void> {
+  const userId = localStorage.getItem("userId");
+  if (!userId) {
+    throw new Error("ユーザー情報が取得できませんでした");
+  }
+  const response = await fetchWithAuth(`/api/users/${userId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ currentPassword, password: newPassword }),
   });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    const message = data.message
+      ? data.message.replace(/\s*ID:\s*\d+/g, "")
+      : `パスワード変更に失敗しました（${response.status}）`;
+    throw new Error(message);
+  }
 }
 
 export default function PasswordSettingsPage() {
@@ -21,15 +35,28 @@ export default function PasswordSettingsPage() {
 
   const handleSubmit = async () => {
     setMessage("");
+    setErrorMessage("");
+
+    if (newPassword.length < 8 || newPassword.length > 127) {
+      setErrorMessage("パスワードは8文字以上、127文字以内で入力してください");
+      return;
+    }
 
     if (newPassword !== confirmPassword) {
       setErrorMessage("新しいパスワードが一致していません");
       return;
     }
 
-    setErrorMessage("");
-    await updatePassword(currentPassword, newPassword);
-    setMessage("パスワード変更の仮処理を実行しました");
+    try {
+      await updatePassword(currentPassword, newPassword);
+      setMessage("パスワードを変更しました");
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "通信エラーが発生しました";
+      setErrorMessage(msg);
+    }
   };
 
   return (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import BackButton from "@/components/BackButton";
+import Link from "next/link";
 import WindowPanel from "@/components/WindowPanel";
 
 type FormErrors = {
@@ -66,6 +66,8 @@ function LoginForm() {
         return;
       }
 
+      const data: { id: number; name: string } = await res.json().catch(() => ({}));
+      localStorage.setItem("userId", String(data.id));
       router.push("/home");
     } catch {
       setErrors({ general: "通信エラーが発生しました" });
@@ -140,7 +142,7 @@ function LoginForm() {
 
               <input
                 id="password"
-                type="password"
+                type="text"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 autoComplete="current-password"
@@ -173,8 +175,12 @@ function LoginForm() {
               </a>
             </p>
           </form>
-
-          <BackButton />
+          <Link
+            href="/"
+            className="mt-8 self-start text-base transition-colors hover:text-yellow-200 sm:text-xl"
+          >
+            ▶ トップページへ
+          </Link>
         </WindowPanel>
       </div>
     </main>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -228,7 +228,7 @@ export default function RegisterPage() {
                 </label>
                 <input
                   id="password"
-                  type="password"
+                  type="text"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   autoComplete="new-password"
@@ -248,7 +248,7 @@ export default function RegisterPage() {
                 </label>
                 <input
                   id="confirmPassword"
-                  type="password"
+                  type="text"
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   autoComplete="new-password"


### PR DESCRIPTION
## 概要
アカウント設定画面のAPI連携を実装

## 対応内容
- アカウント情報取得APIとの連携を追加
- アカウント情報更新APIとの連携を追加
- アカウント削除APIとの連携を追加
- API通信時のエラーハンドリングを追加
- ログイン成功時にレスポンスからユーザーIDを取得し、`localStorage` に保存する処理を追加
- ログイン画面、トップページへのリンクに変更

## 確認内容
- アカウント情報が画面に表示されること
- 入力内容を更新できること
- アカウント削除処理が実行できること
- ログイン成功時に `localStorage` へ `userId` が保存されること
- アカウント設定画面で `localStorage.getItem("userId")` によりユーザーIDを取得し、API呼び出しに使用できること
- ログイン画面からトップページへ遷移できること