### PR TITLE
ランキング画面・スコア履歴画面に共通ヘッダーを追加しました

### DIFF
--- a/src/app/battle/page.tsx
+++ b/src/app/battle/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Client } from "@stomp/stompjs";
+import WindowPanel from "@/components/WindowPanel";
+import TypewriterText from "@/components/TypewriterText";
+import MenuItem from "@/components/MenuItem";
+import { useCurrentUser } from "@/contexts/CurrentUserContext";
+import BackButton from "@/components/BackButton";
+import UserAvatar from "@/components/UserAvatar";
+import { fetchWithAuth } from "@/lib/fetchWithAuth";
+
+type BattleStatus = "searching" | "found" | "ready" | "playing" | "finished";
+
+interface OpponentInfo {
+  id: number;
+  name: string;
+  iconImage: string | null;
+}
+
+export default function BattlePage() {
+  const router = useRouter();
+  const { currentUser, updateCurrentUser } = useCurrentUser();
+  const [status, setStatus] = useState<BattleStatus>("searching");
+  const [matchId, setMatchId] = useState<number | null>(null);
+  const [opponent, setOpponent] = useState<OpponentInfo | null>(null);
+  const [isMessageComplete, setIsMessageComplete] = useState(false);
+
+  const clientRef = useRef<Client | null>(null);
+
+  // --- 0. localStorage からユーザー情報を同期 ---
+  useEffect(() => {
+    const userId = localStorage.getItem("userId");
+    const userName = localStorage.getItem("userName");
+    
+    if (userId && userId !== "0" && userId !== String(currentUser.id)) {
+      // localStorage の情報で一旦更新
+      updateCurrentUser({
+        id: Number(userId),
+        name: userName ?? currentUser.name,
+      });
+
+      // バックエンドから ID, 名前, アイコンのみを取得して反映
+      const syncUser = async () => {
+        try {
+          const res = await fetchWithAuth(`/api/users/${userId}`);
+          if (res.ok) {
+            const data = await res.json();
+            updateCurrentUser({
+              id: data.id,
+              name: data.name,
+              iconImage: data.iconImage,
+            });
+          }
+        } catch (err) {
+          console.error("Failed to sync user info:", err);
+        }
+      };
+
+      syncUser();
+    }
+  }, [currentUser.id, updateCurrentUser]);
+
+  // --- 1. WebSocket 接続とマッチング処理 ---
+  useEffect(() => {
+    // ユーザーIDが確定するまで接続を待機
+    if (currentUser.id === 0) return;
+
+    const client = new Client({
+      brokerURL: "ws://localhost:8080/ws-battle",
+      reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000,
+    });
+
+    client.onConnect = () => {
+      console.log("Connected to WebSocket");
+
+      // マッチング通知を購読
+      client.subscribe(
+        `/topic/match/notification/${currentUser.id}`,
+        (message) => {
+          const data = JSON.parse(message.body);
+          console.log("DEBUG: Match Notification received:", data);
+          if (data.status === "MATCHED") {
+            setMatchId(data.matchId);
+            fetchOpponentInfo(data.opponentId);
+            setStatus("found");
+            setIsMessageComplete(false); // メッセージ演出をリセット
+          } else if (data.status === "CANCELLED") {
+            // 相手が離脱した場合、検索中に戻す
+            console.log("Opponent left. Returning to searching...");
+            setMatchId(null);
+            setOpponent(null);
+            setStatus("searching");
+          }
+        },
+      );
+
+      // マッチング待機列に参加
+      client.publish({
+        destination: "/api/battles/queue/join",
+        body: JSON.stringify({ userId: currentUser.id }),
+      });
+    };
+
+    client.onStompError = (frame) => {
+      console.error("STOMP error", frame);
+    };
+
+    client.activate();
+    clientRef.current = client;
+
+    return () => {
+      if (clientRef.current) {
+        // 接続されている場合のみ離脱通知を送る
+        if (clientRef.current.connected) {
+          clientRef.current.publish({
+            destination: "/api/battles/queue/leave",
+            body: JSON.stringify({ userId: currentUser.id }),
+          });
+        }
+        clientRef.current.deactivate();
+      }
+    };
+  }, [currentUser.id]);
+
+  // 対戦相手の情報取得
+  const fetchOpponentInfo = async (id: number) => {
+    console.log("DEBUG: [fetchOpponentInfo] Attempting to fetch info for ID:", id);
+    try {
+      const res = await fetchWithAuth(`/api/users/${id}`);
+      const data = await res.json();
+      console.log("DEBUG: [fetchOpponentInfo] Received data:", data);
+      setOpponent({
+        id: data.id,
+        name: data.name,
+        iconImage: data.iconImage,
+      });
+    } catch (err) {
+      console.error("Failed to fetch opponent info", err);
+    }
+  };
+
+  const handleFight = () => {
+    // 実際の対戦画面へ（カウントダウン等）
+    setStatus("ready");
+  };
+
+  const handleRun = () => {
+    // 待機列から抜けて再度探す
+    if (clientRef.current && clientRef.current.connected) {
+      clientRef.current.publish({
+        destination: "/api/battles/queue/leave",
+        body: JSON.stringify({ userId: currentUser.id }),
+      });
+    }
+    // 再度探す場合は status を searching に戻し、再度 join させる
+    setStatus("searching");
+    if (clientRef.current && clientRef.current.connected) {
+      clientRef.current.publish({
+        destination: "/api/battles/queue/join",
+        body: JSON.stringify({ userId: currentUser.id }),
+      });
+    }
+  };
+
+  return (
+    <main className="flex flex-1 items-center justify-center p-4">
+      <WindowPanel className="max-w-2xl min-h-[400px]">
+        <div className="flex w-full flex-col items-center py-6">
+          {/* --- ステータス1: 検索中 --- */}
+          {status === "searching" && (
+            <div className="flex flex-col items-center py-16">
+              {/* グルグル（スピンアニメーション） */}
+              <div className="relative mb-12">
+                <div className="h-24 w-24 animate-spin rounded-full border-b-4 border-t-4 border-yellow-400"></div>
+                <div className="absolute inset-0 flex items-center justify-center text-4xl">
+                  ⚔️
+                </div>
+              </div>
+              <p className="text-2xl text-white">
+                <TypewriterText text="対戦相手を さがしています..." />
+              </p>
+              <div className="mt-12">
+                <BackButton />
+              </div>
+            </div>
+          )}
+
+          {/* --- ステータス2: 対戦相手発見 (野生の...が現れた) --- */}
+          {status === "found" && opponent && (
+            <div className="flex w-full flex-col items-center py-8">
+              <div className="flex items-center gap-12 mb-12 animate-bounce">
+                <div className="flex flex-col items-center">
+                  <UserAvatar user={currentUser} size="lg" />
+                  <p className="mt-2 text-sm text-slate-400">あなた</p>
+                </div>
+                <div className="text-5xl font-black italic text-red-600">
+                  VS
+                </div>
+                <div className="flex flex-col items-center">
+                  <UserAvatar user={opponent} size="lg" />
+                  <p className="mt-2 text-sm text-slate-400">あいて</p>
+                </div>
+              </div>
+
+              <div className="w-full bg-black/60 border-4 border-double border-white p-6 text-left min-h-[140px] mb-8">
+                <p className="text-2xl leading-relaxed text-white">
+                  <TypewriterText
+                    text={`やせいの ${opponent.name} が\nあらわれた！`}
+                    speed={50}
+                    onComplete={() => setIsMessageComplete(true)}
+                  />
+                </p>
+              </div>
+
+              {/* 文言が出終わったらメニューを表示 */}
+              <div
+                className={`flex flex-col items-start gap-4 transition-opacity duration-500 ${isMessageComplete ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+              >
+                <button onClick={handleFight} className="text-left w-full">
+                  <MenuItem showCursor>たたかう</MenuItem>
+                </button>
+                <button onClick={handleRun} className="text-left w-full">
+                  <MenuItem showCursor>にげる</MenuItem>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* --- ステータス3: カウントダウン / 準備中 --- */}
+          {status === "ready" && (
+            <div className="flex flex-col items-center py-20">
+              <p className="text-3xl mb-8">じゅんびは いいか！</p>
+              <div className="text-8xl font-black text-yellow-400 animate-ping">
+                3
+              </div>
+            </div>
+          )}
+
+          {/* 実際に対戦が始まったら、ここからプレイ画面のコンポーネントへ繋ぐ */}
+        </div>
+      </WindowPanel>
+    </main>
+  );
+}

--- a/src/app/battle/page.tsx
+++ b/src/app/battle/page.tsx
@@ -26,8 +26,11 @@ export default function BattlePage() {
   const [matchId, setMatchId] = useState<number | null>(null);
   const [opponent, setOpponent] = useState<OpponentInfo | null>(null);
   const [isMessageComplete, setIsMessageComplete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
 
   const clientRef = useRef<Client | null>(null);
+  const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
 
   // --- 0. localStorage からユーザー情報を同期 ---
   useEffect(() => {
@@ -74,26 +77,56 @@ export default function BattlePage() {
       heartbeatOutgoing: 4000,
     });
 
+    const fetchOpponentInfo = async (id: number) => {
+      try {
+        const res = await fetchWithAuth(`/api/users/${id}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        setOpponent({
+          id: data.id,
+          name: data.name,
+          iconImage: data.iconImage,
+        });
+      } catch (err) {
+        console.error("Failed to fetch opponent info:", err);
+        // マッチをなかったことにして検索に戻す
+        setMatchId(null);
+        setOpponent(null);
+        setStatus("searching");
+        setError("あいての じょうほうしゅとくに しっぱいしました。さいど マッチングします。");
+        // 再度待機列に入る処理はバックエンド側で自動的に行われるため、フロントからは送信しない
+      }
+    };
+
     client.onConnect = () => {
-      console.log("Connected to WebSocket");
+      setIsConnected(true);
+      setError(null);
 
       // マッチング通知を購読
-      client.subscribe(
+      subscriptionRef.current = client.subscribe(
         `/topic/match/notification/${currentUser.id}`,
         (message) => {
-          const data = JSON.parse(message.body);
-          console.log("DEBUG: Match Notification received:", data);
+          let data;
+          try {
+            data = JSON.parse(message.body);
+          } catch (e) {
+            console.error("Invalid message format:", message.body);
+            return;
+          }
+
           if (data.status === "MATCHED") {
             setMatchId(data.matchId);
             fetchOpponentInfo(data.opponentId);
             setStatus("found");
             setIsMessageComplete(false); // メッセージ演出をリセット
+            setError(null);
           } else if (data.status === "CANCELLED") {
             // 相手が離脱した場合、検索中に戻す
-            console.log("Opponent left. Returning to searching...");
             setMatchId(null);
             setOpponent(null);
             setStatus("searching");
+            setError("あいてが にげだした！ べつの あいてを さがします。");
+            // 再度待機列に入る処理はバックエンド側で自動的に行われるため、フロントからは送信しない
           }
         },
       );
@@ -107,6 +140,20 @@ export default function BattlePage() {
 
     client.onStompError = (frame) => {
       console.error("STOMP error", frame);
+      setError("サーバーへの接続に失敗しました。再読み込みしてください。");
+      setIsConnected(false);
+    };
+
+    client.onDisconnect = () => {
+      console.log("Disconnected from WebSocket");
+      setIsConnected(false);
+      // 検索中または発見中に意図せず切断された場合
+      setStatus((currentStatus) => {
+        if (currentStatus === "searching" || currentStatus === "found") {
+          setError("せつぞくが きれました。");
+        }
+        return currentStatus;
+      });
     };
 
     client.activate();
@@ -123,65 +170,65 @@ export default function BattlePage() {
         }
         clientRef.current.deactivate();
       }
+      subscriptionRef.current?.unsubscribe();
     };
   }, [currentUser.id]);
 
-  // 対戦相手の情報取得
-  const fetchOpponentInfo = async (id: number) => {
-    console.log("DEBUG: [fetchOpponentInfo] Attempting to fetch info for ID:", id);
-    try {
-      const res = await fetchWithAuth(`/api/users/${id}`);
-      const data = await res.json();
-      console.log("DEBUG: [fetchOpponentInfo] Received data:", data);
-      setOpponent({
-        id: data.id,
-        name: data.name,
-        iconImage: data.iconImage,
-      });
-    } catch (err) {
-      console.error("Failed to fetch opponent info", err);
-    }
-  };
+  // --- 2. ブラウザ強制終了時の対策 ---
+  useEffect(() => {
+    if (currentUser.id === 0) return;
+
+    const handleUnload = () => {
+      navigator.sendBeacon(
+        "/api/battles/queue/leave",
+        JSON.stringify({ userId: currentUser.id })
+      );
+    };
+    window.addEventListener("beforeunload", handleUnload);
+    return () => window.removeEventListener("beforeunload", handleUnload);
+  }, [currentUser.id]);
 
   const handleFight = () => {
+    // 対戦画面へ遷移する前にサブスクリプションを解除
+    subscriptionRef.current?.unsubscribe();
+    subscriptionRef.current = null;
     // 実際の対戦画面へ（カウントダウン等）
     setStatus("ready");
   };
 
   const handleRun = () => {
-    // 待機列から抜けて再度探す
+    // 待機列から抜けてメニュー画面へ戻る（ループ防止の対策1）
     if (clientRef.current && clientRef.current.connected) {
       clientRef.current.publish({
         destination: "/api/battles/queue/leave",
         body: JSON.stringify({ userId: currentUser.id }),
       });
     }
-    // 再度探す場合は status を searching に戻し、再度 join させる
-    setStatus("searching");
-    if (clientRef.current && clientRef.current.connected) {
-      clientRef.current.publish({
-        destination: "/api/battles/queue/join",
-        body: JSON.stringify({ userId: currentUser.id }),
-      });
-    }
+    router.push("/home");
   };
 
   return (
     <main className="flex flex-1 items-center justify-center p-4">
       <WindowPanel className="max-w-2xl min-h-[400px]">
         <div className="flex w-full flex-col items-center py-6">
+          {error && (
+            <div className="mb-4 text-red-400 text-center font-bold animate-pulse">
+              {error}
+            </div>
+          )}
+
           {/* --- ステータス1: 検索中 --- */}
           {status === "searching" && (
             <div className="flex flex-col items-center py-16">
               {/* グルグル（スピンアニメーション） */}
               <div className="relative mb-12">
-                <div className="h-24 w-24 animate-spin rounded-full border-b-4 border-t-4 border-yellow-400"></div>
+                <div className={`h-24 w-24 animate-spin rounded-full border-b-4 border-t-4 ${isConnected ? "border-yellow-400" : "border-gray-500"}`}></div>
                 <div className="absolute inset-0 flex items-center justify-center text-4xl">
-                  ⚔️
+                  {isConnected ? "⚔️" : "☁️"}
                 </div>
               </div>
               <p className="text-2xl text-white">
-                <TypewriterText text="対戦相手を さがしています..." />
+                <TypewriterText text={isConnected ? "対戦相手を さがしています..." : "サーバーに せつぞくちゅう..."} />
               </p>
               <div className="mt-12">
                 <BackButton />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import Link from "next/link";
 import WindowPanel from "@/components/WindowPanel";
+import { useCurrentUser } from "@/contexts/CurrentUserContext";
 
 type FormErrors = {
   email?: string;
@@ -34,6 +35,7 @@ function validate(email: string, password: string): FormErrors {
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { updateCurrentUser } = useCurrentUser();
   const isExpired = searchParams.get("reason") === "expired";
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -62,12 +64,25 @@ function LoginForm() {
 
       if (!res.ok) {
         const data: { message?: string } = await res.json().catch(() => ({}));
-        setErrors({ general: data.message ?? "メールアドレスまたはパスワードが正しくありません" });
+        setErrors({
+          general:
+            data.message ?? "メールアドレスまたはパスワードが正しくありません",
+        });
         return;
       }
 
-      const data: { id: number; name: string } = await res.json().catch(() => ({}));
+      const data: { id: number; name: string } = await res.json();
+
+      // localStorage に ID と名前を保存
       localStorage.setItem("userId", String(data.id));
+      localStorage.setItem("userName", data.name);
+
+      // コンテキストを更新
+      updateCurrentUser({
+        id: data.id,
+        name: data.name,
+      });
+
       router.push("/home");
     } catch {
       setErrors({ general: "通信エラーが発生しました" });

--- a/src/app/rankings/page.tsx
+++ b/src/app/rankings/page.tsx
@@ -94,7 +94,7 @@ export default function RankingsPage() {
 
   return (
     <main className="flex flex-1 items-center justify-center">
-      <div className="[&>section]:h-[500px] [&>section]:w-[750px] [&>section]:pt-3">
+      <div className="[&>section]:h-[650px] [&>section]:w-[750px] [&>section]:pt-3">
         <WindowPanel>
           {/* タイトル */}
           <div className="flex items-center justify-center gap-3">
@@ -160,7 +160,7 @@ export default function RankingsPage() {
           <div className="mt-5 w-full">
             <div className="grid grid-cols-[5rem_1fr_7rem_7rem] gap-2 border-b border-yellow-200/30 pb-1.5 text-sm text-slate-400">
               <span className="pr-5 text-center">順位</span>
-              <span className="pl-2.5 text-left">ユーザー名</span>
+              <span className="pl-2 text-left">ユーザー名</span>
               <span className="pl-2.5 text-left">スコア</span>
               <span className="pl-2.5 text-left">正答率</span>
             </div>
@@ -201,12 +201,12 @@ export default function RankingsPage() {
                     </span>
 
                     {/* スコア */}
-                    <span className="flex items-center justify-center text-sm font-medium tracking-[0.1em] text-slate-300">
+                    <span className="flex items-center pr-8 justify-center text-sm font-medium tracking-[0.1em] text-slate-300">
                       {ranking.score.toLocaleString()}
                     </span>
 
                     {/* 正答率 */}
-                    <span className="flex items-center justify-center text-sm font-medium tracking-[0.1em] text-slate-300">
+                    <span className="flex items-center pr-8 justify-center text-sm font-medium tracking-[0.1em] text-slate-300">
                       {ranking.accuracyRate}%
                     </span>
                   </li>

--- a/src/app/score-history/page.tsx
+++ b/src/app/score-history/page.tsx
@@ -85,7 +85,7 @@ export default function HistoryPage() {
 
   return (
     <main className="flex flex-1 items-center justify-center">
-      <div className="[&>section]:h-[500px] [&>section]:w-[750px] [&>section]:pt-3">
+      <div className="[&>section]:h-[650px] [&>section]:w-[750px] [&>section]:pt-3">
         <WindowPanel>
           {/* タイトル */}
           <div className="flex items-center justify-center gap-3">
@@ -211,12 +211,12 @@ export default function HistoryPage() {
                       </span>
 
                       {/* スコア */}
-                      <span className="flex items-center justify-center text-sm font-medium tracking-[0.1em] text-yellow-200">
+                      <span className="flex items-center pr-8 justify-center text-sm font-medium tracking-[0.1em] text-yellow-200">
                         {history.score.toLocaleString()}
                       </span>
 
                       {/* 正答率 */}
-                      <span className="flex items-center justify-center text-sm font-medium tracking-[0.1em] text-slate-300">
+                      <span className="flex items-center pr-8 justify-center text-sm font-medium tracking-[0.1em] text-slate-300">
                         {history.accuracyRate}%
                       </span>
                     </li>

--- a/src/components/CommonHeader.tsx
+++ b/src/components/CommonHeader.tsx
@@ -25,6 +25,8 @@ const headerVisiblePaths = new Set([
   "/account-settings/delete",
   "/result/BattleResult",
   "/result/SingleResult",
+  "/rankings",
+  "/score-history",
 ]);
 
 export default function CommonHeader() {

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -23,7 +23,7 @@ type CurrentUserContextValue = Readonly<{
 }>;
 
 const mockCurrentUser: CurrentUser = {
-  id: 1,
+  id: 0, //ユーザーIDが被らないよう0に変更
   name: "Guest",
   email: "guest@example.com",
   iconImage: null,


### PR DESCRIPTION
## 概要
ランキング画面・スコア履歴画面に共通ヘッダーを追加しました。

## 主な変更内容
- ランキング画面にヘッダーを追加
- スコア履歴画面にヘッダーを追加
- スコア・正答率の表示位置を調整

## 確認内容
- ランキング画面でヘッダーが表示されること
- スコア履歴画面でヘッダーが表示されること
- スコア・正答率の表示位置が崩れていないこと