### PR TITLE
パスワード再設定画面を作成

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -151,7 +151,7 @@ function LoginForm() {
             </div>
 
             <p className="-mt-1.5 text-left text-sm">
-              <a href="/forgot-password">
+              <a href="/password-reset/request">
                 <span className="text-slate-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
                   パスワードを忘れた方はこちら
                 </span>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -151,11 +151,11 @@ function LoginForm() {
             </div>
 
             <p className="-mt-1.5 text-left text-sm">
-              <a href="/password-reset/request">
+              <Link href="/password-reset/request">
                 <span className="text-slate-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
                   パスワードを忘れた方はこちら
                 </span>
-              </a>
+              </Link>
             </p>
 
             {/* ログインボタン */}
@@ -168,11 +168,11 @@ function LoginForm() {
             </button>
 
             <p className="mt-3 text-center text-[1.15rem]">
-              <a href="/register">
+              <Link href="/register">
                 <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
                   新規登録はこちら
                 </span>
-              </a>
+              </Link>
             </p>
           </form>
           <Link

--- a/src/app/password-reset/confirm/page.tsx
+++ b/src/app/password-reset/confirm/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+
+import WindowPanel from "@/components/WindowPanel";
+
+type FormErrors = {
+  email?: string;
+  general?: string;
+};
+
+const API_BASE = "http://localhost:8080";
+
+function validateEmail(email: string): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!email) {
+    errors.email = "メールアドレスを入力してください";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.email = "メールアドレスの形式が正しくありません";
+  }
+
+  return errors;
+}
+
+export default function PasswordResetRequestPage() {
+  const [email, setEmail] = useState("");
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSent, setIsSent] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const validationErrors = validateEmail(email);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/password-reset/request`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email }),
+      });
+
+      if (!res.ok) {
+        const data: { message?: string } = await res.json().catch(() => ({}));
+        setErrors({
+          general: data.message ?? "送信に失敗しました",
+        });
+        return;
+      }
+
+      setIsSent(true);
+    } catch {
+      setErrors({ general: "通信エラーが発生しました" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="flex flex-1 items-center justify-center overflow-auto">
+      <div className="[&>section]:min-h-[400px] [&>section]:min-w-[600px]">
+        <WindowPanel>
+          <h1 className="text-3xl font-bold tracking-wide text-white">
+            パスワード再設定申請
+          </h1>
+
+          {isSent ? (
+            <div className="mt-6 flex w-full max-w-sm flex-col gap-5">
+              <p className="text-center text-sm leading-relaxed text-slate-200">
+                パスワード再設定用のメールを送信しました。
+                <br />
+                メールに記載されているURLからパスワードを再設定してください。
+              </p>
+              <p className="text-center text-sm text-slate-300">
+                <a href="/login">
+                  <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
+                    ログイン画面に戻る
+                  </span>
+                </a>
+              </p>
+            </div>
+          ) : (
+            <form
+              onSubmit={handleSubmit}
+              noValidate
+              className="mt-6 flex w-full max-w-sm flex-col gap-5"
+            >
+              <p className="whitespace-nowrap -mt-3 text-left text-sm text-slate-300">
+                登録済みのメールアドレスを入力してください。
+              </p>
+
+              {/* 通信エラー */}
+              <p
+                role={errors.general ? "alert" : undefined}
+                className={`min-h-[25px] -mt-3 text-left text-base ${errors.general ? "text-red-400" : "text-transparent"}`}
+              >
+                {errors.general ?? "\u00A0"}
+              </p>
+
+              {/* メールアドレス */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="email"
+                  role={errors.email ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.email ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.email ?? "メールアドレス"}
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="email"
+                  placeholder="*****@outlook.jp"
+                  className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+              </div>
+
+              {/* 送信ボタン */}
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="mt-1 border border-slate-400 bg-[#0d1b3e]/60 py-2 text-lg font-bold tracking-[0.03em] text-white hover:border-yellow-200 hover:text-yellow-200 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? "読み込み中..." : "送信する"}
+              </button>
+
+              <p className="text-center text-sm text-slate-300">
+                <a href="/login">
+                  <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
+                    ログイン画面に戻る
+                  </span>
+                </a>
+              </p>
+            </form>
+          )}
+        </WindowPanel>
+      </div>
+    </main>
+  );
+}

--- a/src/app/password-reset/request/page.tsx
+++ b/src/app/password-reset/request/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 import WindowPanel from "@/components/WindowPanel";
 
 type FormErrors = {
+  email?: string;
   password?: string;
   confirmPassword?: string;
   general?: string;
@@ -13,8 +13,18 @@ type FormErrors = {
 
 const API_BASE = "http://localhost:8080";
 
-function validatePasswords(password: string, confirmPassword: string): FormErrors {
+function validateForm(
+  email: string,
+  password: string,
+  confirmPassword: string
+): FormErrors {
   const errors: FormErrors = {};
+
+  if (!email) {
+    errors.email = "メールアドレスを入力してください";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.email = "メールアドレスの形式が正しくありません";
+  }
 
   if (!password) {
     errors.password = "新しいパスワードを入力してください";
@@ -31,28 +41,20 @@ function validatePasswords(password: string, confirmPassword: string): FormError
   return errors;
 }
 
-export default function PasswordResetConfirmPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams.get("token") ?? "";
-
+export default function PasswordResetRequestPage() {
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  useEffect(() => {
-    if (!token) {
-      setErrors({ general: "無効なリンクです。再度パスワード再設定をお試しください。" });
-    }
-  }, [token]);
+  const [isSent, setIsSent] = useState(false);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
-    const validationErrors = validatePasswords(password, confirmPassword);
+    const validationErrors = validateForm(email, password, confirmPassword);
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
       return;
@@ -62,30 +64,22 @@ export default function PasswordResetConfirmPage() {
     setErrors({});
 
     try {
-      const res = await fetch(`${API_BASE}/api/auth/password-reset/confirm`, {
+      const res = await fetch(`${API_BASE}/api/auth/password-reset/request`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ token, password }),
+        body: JSON.stringify({ email, password }),
       });
 
       if (!res.ok) {
         const data: { message?: string } = await res.json().catch(() => ({}));
-
-        if (res.status === 400 || res.status === 401) {
-          setErrors({
-            general: data.message ?? "リンクの有効期限が切れているか、無効なリンクです。",
-          });
-          return;
-        }
-
         setErrors({
-          general: data.message ?? "パスワードの再設定に失敗しました",
+          general: data.message ?? "送信に失敗しました",
         });
         return;
       }
 
-      router.push("/login");
+      setIsSent(true);
     } catch {
       setErrors({ general: "通信エラーが発生しました" });
     } finally {
@@ -95,124 +89,158 @@ export default function PasswordResetConfirmPage() {
 
   return (
     <main className="flex flex-1 items-center justify-center overflow-auto">
-      <div className="[&>section]:min-h-[500px] [&>section]:min-w-[600px]">
+      <div className="[&>section]:min-h-[400px] [&>section]:min-w-[600px]">
         <WindowPanel>
           <h1 className="text-3xl font-bold tracking-wide text-white">
-            パスワード再設定
+            パスワード再設定申請
           </h1>
 
-          <form
-            onSubmit={handleSubmit}
-            noValidate
-            className="mt-6 flex w-full max-w-sm flex-col gap-5"
-          >
-            <p className="whitespace-pre-wrap -mt-3 text-left text-sm text-slate-300">
-              {"新しいパスワードを入力してください。\n8文字以上、127文字以内で設定してください。"}
-            </p>
-
-            {/* 通信エラー */}
-            <p
-              role={errors.general ? "alert" : undefined}
-              className={`min-h-[25px] -mt-3 text-left text-base ${errors.general ? "text-red-400" : "text-transparent"}`}
-            >
-              {errors.general ?? "\u00A0"}
-            </p>
-
-            {/* 新しいパスワード */}
-            <div className="flex flex-col gap-1">
-              <label
-                htmlFor="password"
-                role={errors.password ? "alert" : undefined}
-                className={`min-h-[20px] text-left text-sm ${errors.password ? "text-red-300" : "text-slate-200"}`}
-              >
-                {errors.password ?? "新しいパスワード"}
-              </label>
-              <div className="relative">
-                <input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  autoComplete="new-password"
-                  placeholder="新しいパスワードを入力してください"
-                  className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
-                  aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示する"}
-                >
-                  {showPassword ? (
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                    </svg>
-                  ) : (
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                    </svg>
-                  )}
-                </button>
-              </div>
+          {isSent ? (
+            <div className="mt-6 flex w-full max-w-sm flex-col gap-5">
+              <p className="text-center text-sm leading-relaxed text-slate-200">
+                パスワード再設定用のメールを送信しました。
+                <br />
+                メールに記載されているURLからパスワードを再設定してください。
+              </p>
+              <p className="text-center text-sm text-slate-300">
+                <a href="/login">
+                  <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
+                    ログイン画面に戻る
+                  </span>
+                </a>
+              </p>
             </div>
-
-            {/* 新しいパスワード（確認用） */}
-            <div className="flex flex-col gap-1">
-              <label
-                htmlFor="confirmPassword"
-                role={errors.confirmPassword ? "alert" : undefined}
-                className={`min-h-[20px] text-left text-sm ${errors.confirmPassword ? "text-red-300" : "text-slate-200"}`}
-              >
-                {errors.confirmPassword ?? "新しいパスワード（確認用）"}
-              </label>
-              <div className="relative">
-                <input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  autoComplete="new-password"
-                  placeholder="新しいパスワードを再入力してください"
-                  className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
-                  aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示する"}
-                >
-                  {showConfirmPassword ? (
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                    </svg>
-                  ) : (
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                    </svg>
-                  )}
-                </button>
-              </div>
-            </div>
-
-            {/* 更新ボタン */}
-            <button
-              type="submit"
-              disabled={isSubmitting || !token}
-              className="mt-1 border border-slate-400 bg-[#0d1b3e]/60 py-2 text-lg font-bold tracking-[0.03em] text-white hover:border-yellow-200 hover:text-yellow-200 disabled:cursor-not-allowed disabled:opacity-50"
+          ) : (
+            <form
+              onSubmit={handleSubmit}
+              noValidate
+              className="mt-6 flex w-full max-w-sm flex-col gap-5"
             >
-              {isSubmitting ? "読み込み中..." : "パスワードを更新する"}
-            </button>
 
-            <p className="text-center text-sm text-slate-300">
-              <a href="/login">
-                <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
-                  ログイン画面に戻る
-                </span>
-              </a>
-            </p>
-          </form>
+              {/* 通信エラー */}
+              <p
+                role={errors.general ? "alert" : undefined}
+                className={`min-h-[25px] -mt-3 text-left text-base ${errors.general ? "text-red-400" : "text-transparent"}`}
+              >
+                {errors.general ?? "\u00A0"}
+              </p>
+
+              {/* メールアドレス */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="email"
+                  role={errors.email ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.email ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.email ?? "メールアドレス"}
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="email"
+                  placeholder="*****@outlook.jp"
+                  className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+              </div>
+
+              {/* 新しいパスワード */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="password"
+                  role={errors.password ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.password ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.password ?? "新しいパスワード"}
+                </label>
+                <div className="relative">
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    autoComplete="new-password"
+                    placeholder="新しいパスワードを入力してください"
+                    className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
+                    aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示する"}
+                  >
+                    {showPassword ? (
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                      </svg>
+                    ) : (
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                      </svg>
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {/* 新しいパスワード（確認用） */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="confirmPassword"
+                  role={errors.confirmPassword ? "alert" : undefined}
+                  className={`min-h-[20px] text-left text-sm ${errors.confirmPassword ? "text-red-300" : "text-slate-200"}`}
+                >
+                  {errors.confirmPassword ?? "新しいパスワード（確認用）"}
+                </label>
+                <div className="relative">
+                  <input
+                    id="confirmPassword"
+                    type={showConfirmPassword ? "text" : "password"}
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    autoComplete="new-password"
+                    placeholder="新しいパスワードを再入力してください"
+                    className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword((v) => !v)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
+                    aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示する"}
+                  >
+                    {showConfirmPassword ? (
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                      </svg>
+                    ) : (
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                      </svg>
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {/* 送信ボタン */}
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="mt-1 border border-slate-400 bg-[#0d1b3e]/60 py-2 text-lg font-bold tracking-[0.03em] text-white hover:border-yellow-200 hover:text-yellow-200 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? "読み込み中..." : "送信する"}
+              </button>
+
+              <p className="text-center text-sm text-slate-300">
+                <a href="/login">
+                  <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
+                    ログイン画面に戻る
+                  </span>
+                </a>
+              </p>
+            </form>
+          )}
         </WindowPanel>
       </div>
     </main>

--- a/src/app/password-reset/request/page.tsx
+++ b/src/app/password-reset/request/page.tsx
@@ -1,23 +1,21 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
+import VerificationCodeForm from "@/components/VerificationCodeForm";
 import WindowPanel from "@/components/WindowPanel";
+import Link from "next/link";
 
 type FormErrors = {
   email?: string;
-  password?: string;
-  confirmPassword?: string;
+  verificationCode?: string;
   general?: string;
 };
 
 const API_BASE = "http://localhost:8080";
 
-function validateForm(
-  email: string,
-  password: string,
-  confirmPassword: string
-): FormErrors {
+function validateEmail(email: string): FormErrors {
   const errors: FormErrors = {};
 
   if (!email) {
@@ -26,35 +24,27 @@ function validateForm(
     errors.email = "メールアドレスの形式が正しくありません";
   }
 
-  if (!password) {
-    errors.password = "新しいパスワードを入力してください";
-  } else if (password.length < 8 || password.length > 127) {
-    errors.password = "パスワードは8文字以上、127文字以内で入力してください";
-  }
-
-  if (!confirmPassword) {
-    errors.confirmPassword = "確認用パスワードを入力してください";
-  } else if (password !== confirmPassword) {
-    errors.confirmPassword = "パスワードが一致しません";
-  }
-
   return errors;
 }
 
 export default function PasswordResetRequestPage() {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [errors, setErrors] = useState<FormErrors>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isSent, setIsSent] = useState(false);
+  const [step, setStep] = useState<"request" | "verify">("request");
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  const [email, setEmail] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const [resendSuccess, setResendSuccess] = useState(false);
+
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  const router = useRouter();
+
+  async function handleRequest(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
-    const validationErrors = validateForm(email, password, confirmPassword);
+    const validationErrors = validateEmail(email);
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
       return;
@@ -68,18 +58,89 @@ export default function PasswordResetRequestPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email }),
       });
 
       if (!res.ok) {
-        const data: { message?: string } = await res.json().catch(() => ({}));
-        setErrors({
-          general: data.message ?? "送信に失敗しました",
-        });
+        if (res.status === 404) {
+          setErrors({ email: "登録されていないメールアドレスです" });
+          return;
+        }
+
+        setErrors({ general: "送信に失敗しました" });
         return;
       }
 
-      setIsSent(true);
+      setStep("verify");
+      setErrors({});
+    } catch {
+      setErrors({ general: "通信エラーが発生しました" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleVerify(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    if (!verificationCode.trim()) {
+      setErrors({ verificationCode: "認証コードを入力してください" });
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/otp/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email, otp: verificationCode }),
+      });
+
+      if (!res.ok) {
+        setErrors({ general: "認証コードが正しくありません" });
+        return;
+      }
+
+      router.push("/password-reset/reset");
+    } catch {
+      setErrors({ general: "通信エラーが発生しました" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleReSend() {
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/password-reset/request`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email }),
+      });
+
+      if (!res.ok) {
+        setErrors({ general: "再送信に失敗しました" });
+        return;
+      }
+
+      // 成功フィードバック
+      setResendSuccess(true);
+      setTimeout(() => setResendSuccess(false), 3000);
+
+      // 30秒クールダウン
+      setResendCooldown(30);
+      const timer = setInterval(() => {
+        setResendCooldown((prev) => {
+          if (prev <= 1) { clearInterval(timer); return 0; }
+          return prev - 1;
+        });
+      }, 1000);
     } catch {
       setErrors({ general: "通信エラーが発生しました" });
     } finally {
@@ -95,32 +156,20 @@ export default function PasswordResetRequestPage() {
             パスワード再設定申請
           </h1>
 
-          {isSent ? (
-            <div className="mt-6 flex w-full max-w-sm flex-col gap-5">
-              <p className="text-center text-sm leading-relaxed text-slate-200">
-                パスワード再設定用のメールを送信しました。
-                <br />
-                メールに記載されているURLからパスワードを再設定してください。
-              </p>
-              <p className="text-center text-sm text-slate-300">
-                <a href="/login">
-                  <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
-                    ログイン画面に戻る
-                  </span>
-                </a>
-              </p>
-            </div>
-          ) : (
+          {step === "request" ? (
             <form
-              onSubmit={handleSubmit}
+              onSubmit={handleRequest}
               noValidate
               className="mt-6 flex w-full max-w-sm flex-col gap-5"
             >
+              <p className="whitespace-nowrap -mt-3 text-left text-sm text-slate-300">
+                登録済みのメールアドレスを入力してください。
+              </p>
 
               {/* 通信エラー */}
               <p
                 role={errors.general ? "alert" : undefined}
-                className={`min-h-[25px] -mt-3 text-left text-base ${errors.general ? "text-red-400" : "text-transparent"}`}
+                className={`min-h-[25px] -mt-3 text-left text-sm ${errors.general ? "text-red-400" : "text-transparent"}`}
               >
                 {errors.general ?? "\u00A0"}
               </p>
@@ -145,84 +194,6 @@ export default function PasswordResetRequestPage() {
                 />
               </div>
 
-              {/* 新しいパスワード */}
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="password"
-                  role={errors.password ? "alert" : undefined}
-                  className={`min-h-[20px] text-left text-sm ${errors.password ? "text-red-300" : "text-slate-200"}`}
-                >
-                  {errors.password ?? "新しいパスワード"}
-                </label>
-                <div className="relative">
-                  <input
-                    id="password"
-                    type={showPassword ? "text" : "password"}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    autoComplete="new-password"
-                    placeholder="新しいパスワードを入力してください"
-                    className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword((v) => !v)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
-                    aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示する"}
-                  >
-                    {showPassword ? (
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                      </svg>
-                    ) : (
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                      </svg>
-                    )}
-                  </button>
-                </div>
-              </div>
-
-              {/* 新しいパスワード（確認用） */}
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="confirmPassword"
-                  role={errors.confirmPassword ? "alert" : undefined}
-                  className={`min-h-[20px] text-left text-sm ${errors.confirmPassword ? "text-red-300" : "text-slate-200"}`}
-                >
-                  {errors.confirmPassword ?? "新しいパスワード（確認用）"}
-                </label>
-                <div className="relative">
-                  <input
-                    id="confirmPassword"
-                    type={showConfirmPassword ? "text" : "password"}
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    autoComplete="new-password"
-                    placeholder="新しいパスワードを再入力してください"
-                    className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowConfirmPassword((v) => !v)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
-                    aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示する"}
-                  >
-                    {showConfirmPassword ? (
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
-                      </svg>
-                    ) : (
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                      </svg>
-                    )}
-                  </button>
-                </div>
-              </div>
-
               {/* 送信ボタン */}
               <button
                 type="submit"
@@ -233,13 +204,27 @@ export default function PasswordResetRequestPage() {
               </button>
 
               <p className="text-center text-sm text-slate-300">
-                <a href="/login">
+                <Link href="/login">
                   <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
                     ログイン画面に戻る
                   </span>
-                </a>
+                </Link>
               </p>
             </form>
+          ) : (
+            <VerificationCodeForm
+              verificationCode={verificationCode}
+              onCodeChange={setVerificationCode}
+              onSubmit={handleVerify}
+              onResend={handleReSend}
+              isSubmitting={isSubmitting}
+              error={errors.general}
+              fieldError={errors.verificationCode}
+              variant="register"
+              // 後で外す
+              // resendCooldown={resendCooldown}
+              // resendSuccess={resendSuccess}
+            />
           )}
         </WindowPanel>
       </div>

--- a/src/app/password-reset/request/page.tsx
+++ b/src/app/password-reset/request/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import WindowPanel from "@/components/WindowPanel";
+
+type FormErrors = {
+  password?: string;
+  confirmPassword?: string;
+  general?: string;
+};
+
+const API_BASE = "http://localhost:8080";
+
+function validatePasswords(password: string, confirmPassword: string): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!password) {
+    errors.password = "新しいパスワードを入力してください";
+  } else if (password.length < 8 || password.length > 127) {
+    errors.password = "パスワードは8文字以上、127文字以内で入力してください";
+  }
+
+  if (!confirmPassword) {
+    errors.confirmPassword = "確認用パスワードを入力してください";
+  } else if (password !== confirmPassword) {
+    errors.confirmPassword = "パスワードが一致しません";
+  }
+
+  return errors;
+}
+
+export default function PasswordResetConfirmPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setErrors({ general: "無効なリンクです。再度パスワード再設定をお試しください。" });
+    }
+  }, [token]);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const validationErrors = validatePasswords(password, confirmPassword);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/password-reset/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ token, password }),
+      });
+
+      if (!res.ok) {
+        const data: { message?: string } = await res.json().catch(() => ({}));
+
+        if (res.status === 400 || res.status === 401) {
+          setErrors({
+            general: data.message ?? "リンクの有効期限が切れているか、無効なリンクです。",
+          });
+          return;
+        }
+
+        setErrors({
+          general: data.message ?? "パスワードの再設定に失敗しました",
+        });
+        return;
+      }
+
+      router.push("/login");
+    } catch {
+      setErrors({ general: "通信エラーが発生しました" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="flex flex-1 items-center justify-center overflow-auto">
+      <div className="[&>section]:min-h-[500px] [&>section]:min-w-[600px]">
+        <WindowPanel>
+          <h1 className="text-3xl font-bold tracking-wide text-white">
+            パスワード再設定
+          </h1>
+
+          <form
+            onSubmit={handleSubmit}
+            noValidate
+            className="mt-6 flex w-full max-w-sm flex-col gap-5"
+          >
+            <p className="whitespace-pre-wrap -mt-3 text-left text-sm text-slate-300">
+              {"新しいパスワードを入力してください。\n8文字以上、127文字以内で設定してください。"}
+            </p>
+
+            {/* 通信エラー */}
+            <p
+              role={errors.general ? "alert" : undefined}
+              className={`min-h-[25px] -mt-3 text-left text-base ${errors.general ? "text-red-400" : "text-transparent"}`}
+            >
+              {errors.general ?? "\u00A0"}
+            </p>
+
+            {/* 新しいパスワード */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="password"
+                role={errors.password ? "alert" : undefined}
+                className={`min-h-[20px] text-left text-sm ${errors.password ? "text-red-300" : "text-slate-200"}`}
+              >
+                {errors.password ?? "新しいパスワード"}
+              </label>
+              <div className="relative">
+                <input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete="new-password"
+                  placeholder="新しいパスワードを入力してください"
+                  className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
+                  aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示する"}
+                >
+                  {showPassword ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* 新しいパスワード（確認用） */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="confirmPassword"
+                role={errors.confirmPassword ? "alert" : undefined}
+                className={`min-h-[20px] text-left text-sm ${errors.confirmPassword ? "text-red-300" : "text-slate-200"}`}
+              >
+                {errors.confirmPassword ?? "新しいパスワード（確認用）"}
+              </label>
+              <div className="relative">
+                <input
+                  id="confirmPassword"
+                  type={showConfirmPassword ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
+                  placeholder="新しいパスワードを再入力してください"
+                  className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
+                  aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示する"}
+                >
+                  {showConfirmPassword ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* 更新ボタン */}
+            <button
+              type="submit"
+              disabled={isSubmitting || !token}
+              className="mt-1 border border-slate-400 bg-[#0d1b3e]/60 py-2 text-lg font-bold tracking-[0.03em] text-white hover:border-yellow-200 hover:text-yellow-200 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? "読み込み中..." : "パスワードを更新する"}
+            </button>
+
+            <p className="text-center text-sm text-slate-300">
+              <a href="/login">
+                <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
+                  ログイン画面に戻る
+                </span>
+              </a>
+            </p>
+          </form>
+        </WindowPanel>
+      </div>
+    </main>
+  );
+}

--- a/src/app/password-reset/reset/page.tsx
+++ b/src/app/password-reset/reset/page.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import WindowPanel from "@/components/WindowPanel";
+import Link from "next/link";
+
+type FormErrors = {
+  password?: string;
+  confirmPassword?: string;
+  general?: string;
+};
+
+const API_BASE = "http://localhost:8080";
+
+function validatePasswords(password: string, confirmPassword: string): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!password) {
+    errors.password = "新しいパスワードを入力してください";
+  } else if (password.length < 8 || password.length > 127) {
+    errors.password = "パスワードは8文字以上、127文字以内で入力してください";
+  }
+
+  if (!confirmPassword) {
+    errors.confirmPassword = "確認用パスワードを入力してください";
+  } else if (password !== confirmPassword) {
+    errors.confirmPassword = "パスワードが一致しません";
+  }
+
+  return errors;
+}
+
+function EyeIcon({ visible }: { visible: boolean }) {
+  if (visible) {
+    return (
+      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+    </svg>
+  );
+}
+
+export default function PasswordResetResetPage() {
+  const router = useRouter();
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // クッキーの有無をサーバーに確認する
+  useEffect(() => {
+    async function checkSession() {
+      try {
+        const res = await fetch(`${API_BASE}/api/auth/password-reset/verify-session`, {
+          method: "GET",
+          credentials: "include",
+        });
+        if (!res.ok) {
+          setErrors({ general: "有効期限が切れています。再度お試しください。" });
+          setIsSubmitting(true);
+
+          setTimeout(() => {
+            router.push("/password-reset");
+          }, 2000);
+
+          return;
+        }
+      } catch {
+        setErrors({ general: "通信エラーが発生しました" });
+      }
+    }
+    checkSession();
+  }, [router]);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+
+    const validationErrors = validatePasswords(password, confirmPassword);
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrors({});
+
+    try {
+      // emailはクッキーでバックエンドが参照するため送信不要
+      const res = await fetch(`${API_BASE}/api/auth/password-reset/reset`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ password }),
+      });
+
+      if (!res.ok) {
+        setErrors({ general: "パスワードの更新に失敗しました" });
+        return;
+      }
+
+      router.push("/login");
+    } catch {
+      setErrors({ general: "通信エラーが発生しました" });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="flex flex-1 items-center justify-center overflow-auto">
+      <div className="[&>section]:min-h-[500px] [&>section]:min-w-[600px]">
+        <WindowPanel>
+          <h1 className="text-3xl font-bold tracking-wide text-white">
+            パスワード再設定
+          </h1>
+
+          <form
+            onSubmit={handleSubmit}
+            noValidate
+            className="mt-6 flex w-full max-w-sm flex-col gap-5"
+          >
+            <p className="whitespace-pre-wrap -mt-3 text-left text-sm text-slate-300">
+              {"新しいパスワードを入力してください。\n8文字以上、127文字以内で設定してください。"}
+            </p>
+
+            {/* 通信エラー */}
+            <p
+              role={errors.general ? "alert" : undefined}
+              className={`min-h-[25px] -mt-3 text-left text-sm ${errors.general ? "text-red-400" : "text-transparent"}`}
+            >
+              {errors.general ?? "\u00A0"}
+            </p>
+
+            {/* 新しいパスワード */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="password"
+                role={errors.password ? "alert" : undefined}
+                className={`min-h-[20px] text-left text-sm ${errors.password ? "text-red-300" : "text-slate-200"}`}
+              >
+                {errors.password ?? "新しいパスワード"}
+              </label>
+              <div className="relative">
+                <input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete="new-password"
+                  placeholder="新しいパスワードを入力してください"
+                  className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
+                  aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示する"}
+                >
+                  <EyeIcon visible={showPassword} />
+                </button>
+              </div>
+            </div>
+
+            {/* 新しいパスワード（確認用） */}
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="confirmPassword"
+                role={errors.confirmPassword ? "alert" : undefined}
+                className={`min-h-[20px] text-left text-sm ${errors.confirmPassword ? "text-red-300" : "text-slate-200"}`}
+              >
+                {errors.confirmPassword ?? "新しいパスワード（確認用）"}
+              </label>
+              <div className="relative">
+                <input
+                  id="confirmPassword"
+                  type={showConfirmPassword ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
+                  placeholder="新しいパスワードを再入力してください"
+                  className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200"
+                  aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示する"}
+                >
+                  <EyeIcon visible={showConfirmPassword} />
+                </button>
+              </div>
+            </div>
+
+            {/* 更新ボタン */}
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="mt-1 border border-slate-400 bg-[#0d1b3e]/60 py-2 text-lg font-bold tracking-[0.03em] text-white hover:border-yellow-200 hover:text-yellow-200 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? "読み込み中..." : "パスワードを更新する"}
+            </button>
+
+            <p className="text-center text-sm text-slate-300">
+              <Link href="/login">
+                <span className="text-blue-300 underline-offset-2 transition-colors hover:text-sky-400 hover:underline">
+                  ログイン画面に戻る
+                </span>
+              </Link>
+            </p>
+          </form>
+        </WindowPanel>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 概要

パスワード再設定画面を作成しました。

## 主な変更内容

- パスワード再設定申請画面を作成
- メールアドレス入力後、認証コード入力画面へ切り替わる処理を追加
- 認証コード確認後、パスワード再設定画面へ遷移する処理を追加
- パスワード再設定画面を作成
- パスワード入力・確認用パスワード入力のバリデーションを追加
- Cookie の有効期限切れ時に、再設定申請画面へ戻す処理を追加
- APIエラー時の表示メッセージを固定文言に統一

## 確認内容

- メールアドレス未入力時にエラーメッセージが表示されること
- メールアドレス形式が不正な場合にエラーメッセージが表示されること
- 登録されていないメールアドレスの場合にエラーメッセージが表示されること
- 認証コード未入力時にエラーメッセージが表示されること
- 認証コードが不正な場合にエラーメッセージが表示されること
- パスワード未入力時にエラーメッセージが表示されること
- パスワードが8文字未満、または127文字を超える場合にエラーメッセージが表示されること
- 確認用パスワード未入力時にエラーメッセージが表示されること
- パスワードと確認用パスワードが一致しない場合にエラーメッセージが表示されること
- パスワード更新成功後、ログイン画面へ遷移すること