### PR TITLE
入力フォームのバリデーションを整理する

### DIFF
--- a/src/app/account-settings/page.tsx
+++ b/src/app/account-settings/page.tsx
@@ -8,6 +8,10 @@ import UserAvatar from "@/components/UserAvatar";
 import WindowPanel from "@/components/WindowPanel";
 import { useCurrentUser } from "@/contexts/CurrentUserContext";
 import { fetchWithAuth } from "@/lib/fetchWithAuth";
+import {
+  removeUserNameSpaces,
+  validateUserName,
+} from "@/lib/validation";
 
 const MAX_NAME_LENGTH = 50;
 
@@ -51,14 +55,17 @@ function PlayerNameModal(props: PlayerNameModalProps) {
   }, []);
 
   const handleSave = async () => {
-    const trimmedValue = value.trim();
-    if (!trimmedValue) return;
+    const validationError = validateUserName(value);
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
 
     setIsSubmitting(true);
     setErrorMessage("");
 
     try {
-      await props.onSave(trimmedValue);
+      await props.onSave(value);
     } catch (error) {
       setErrorMessage(
         error instanceof Error
@@ -71,7 +78,7 @@ function PlayerNameModal(props: PlayerNameModalProps) {
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
+    setValue(removeUserNameSpaces(e.target.value));
 
     if (errorMessage) {
       setErrorMessage("");
@@ -112,7 +119,7 @@ function PlayerNameModal(props: PlayerNameModalProps) {
           />
 
           <p className="text-xs text-white/50">
-            {MAX_NAME_LENGTH}文字まで入力できます
+            {MAX_NAME_LENGTH}文字まで入力できます（スペースは使用できません）
           </p>
 
           <p
@@ -135,7 +142,7 @@ function PlayerNameModal(props: PlayerNameModalProps) {
           <button
             type="button"
             onClick={handleSave}
-            disabled={!value.trim() || isSubmitting}
+            disabled={Boolean(validateUserName(value)) || isSubmitting}
             className="flex-1 cursor-pointer border-2 border-white bg-[#050816] py-1.5 font-bold transition-colors hover:border-blue-400 hover:text-blue-400 disabled:cursor-not-allowed disabled:opacity-40"
           >
             {isSubmitting ? "保存中" : "OK"}

--- a/src/app/account-settings/page.tsx
+++ b/src/app/account-settings/page.tsx
@@ -119,7 +119,7 @@ function PlayerNameModal(props: PlayerNameModalProps) {
           />
 
           <p className="text-xs text-white/50">
-            {MAX_NAME_LENGTH}文字まで入力できます（スペースは使用できません）
+            {MAX_NAME_LENGTH}文字まで入力できます
           </p>
 
           <p

--- a/src/app/account-settings/password/page.tsx
+++ b/src/app/account-settings/password/page.tsx
@@ -10,7 +10,7 @@ import {
   removePasswordSpaces,
   validateConfirmPassword,
   validateCurrentPassword,
-  validatePassword,
+  validateNewPassword,
 } from "@/lib/validation";
 
 async function updatePassword(currentPassword: string, newPassword: string): Promise<void> {
@@ -54,7 +54,7 @@ export default function PasswordSettingsPage() {
       return;
     }
 
-    const newPasswordError = validatePassword(newPassword);
+    const newPasswordError = validateNewPassword(newPassword);
     if (newPasswordError) {
       setErrorMessage(newPasswordError);
       return;
@@ -106,7 +106,7 @@ export default function PasswordSettingsPage() {
               <input
                 type={showCurrentPassword ? "text" : "password"}
                 value={currentPassword}
-                onChange={(event) => setCurrentPassword(removePasswordSpaces(event.target.value))}
+                onChange={(event) => setCurrentPassword(event.target.value)}
                 className="w-full border-2 border-white bg-[#050816] px-4 py-3 pr-12 text-white outline-none focus:border-yellow-200"
                 required
               />

--- a/src/app/account-settings/password/page.tsx
+++ b/src/app/account-settings/password/page.tsx
@@ -7,6 +7,7 @@ import EyeIcon from "@/components/EyeIcon";
 import WindowPanel from "@/components/WindowPanel";
 import { fetchWithAuth } from "@/lib/fetchWithAuth";
 import {
+  removePasswordSpaces,
   validateConfirmPassword,
   validatePassword,
 } from "@/lib/validation";
@@ -103,7 +104,7 @@ export default function PasswordSettingsPage() {
               <input
                 type={showCurrentPassword ? "text" : "password"}
                 value={currentPassword}
-                onChange={(event) => setCurrentPassword(event.target.value)}
+                onChange={(event) => setCurrentPassword(removePasswordSpaces(event.target.value))}
                 className="w-full border-2 border-white bg-[#050816] px-4 py-3 pr-12 text-white outline-none focus:border-yellow-200"
                 required
               />
@@ -124,7 +125,7 @@ export default function PasswordSettingsPage() {
               <input
                 type={showNewPassword ? "text" : "password"}
                 value={newPassword}
-                onChange={(event) => setNewPassword(event.target.value)}
+                onChange={(event) => setNewPassword(removePasswordSpaces(event.target.value))}
                 className="w-full border-2 border-white bg-[#050816] px-4 py-3 pr-12 text-white outline-none focus:border-yellow-200"
                 required
               />
@@ -145,7 +146,7 @@ export default function PasswordSettingsPage() {
               <input
                 type={showConfirmPassword ? "text" : "password"}
                 value={confirmPassword}
-                onChange={(event) => setConfirmPassword(event.target.value)}
+                onChange={(event) => setConfirmPassword(removePasswordSpaces(event.target.value))}
                 className="w-full border-2 border-white bg-[#050816] px-4 py-3 pr-12 text-white outline-none focus:border-yellow-200"
                 required
               />

--- a/src/app/account-settings/password/page.tsx
+++ b/src/app/account-settings/password/page.tsx
@@ -9,6 +9,7 @@ import { fetchWithAuth } from "@/lib/fetchWithAuth";
 import {
   removePasswordSpaces,
   validateConfirmPassword,
+  validateCurrentPassword,
   validatePassword,
 } from "@/lib/validation";
 
@@ -47,8 +48,9 @@ export default function PasswordSettingsPage() {
     setMessage("");
     setErrorMessage("");
 
-    if (!currentPassword) {
-      setErrorMessage("現在のパスワードを入力してください");
+    const currentPasswordError = validateCurrentPassword(currentPassword);
+    if (currentPasswordError) {
+      setErrorMessage(currentPasswordError);
       return;
     }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import EyeIcon from "@/components/EyeIcon";
 import WindowPanel from "@/components/WindowPanel";
 import {
+  removePasswordSpaces,
   validateEmail,
   validatePassword,
   type ValidationErrors,
@@ -141,7 +142,7 @@ function LoginForm() {
                   id="password"
                   type={showPassword ? "text" : "password"}
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
+                  onChange={(e) => setPassword(removePasswordSpaces(e.target.value))}
                   autoComplete="current-password"
                   className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
                 />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,7 +7,6 @@ import Link from "next/link";
 import EyeIcon from "@/components/EyeIcon";
 import WindowPanel from "@/components/WindowPanel";
 import {
-  removePasswordSpaces,
   validateEmail,
   validatePassword,
   type ValidationErrors,
@@ -142,7 +141,7 @@ function LoginForm() {
                   id="password"
                   type={showPassword ? "text" : "password"}
                   value={password}
-                  onChange={(e) => setPassword(removePasswordSpaces(e.target.value))}
+                  onChange={(e) => setPassword(e.target.value)}
                   autoComplete="current-password"
                   className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
                 />

--- a/src/app/password-reset/new/page.tsx
+++ b/src/app/password-reset/new/page.tsx
@@ -8,7 +8,7 @@ import WindowPanel from "@/components/WindowPanel";
 import {
   removePasswordSpaces,
   validateConfirmPassword,
-  validatePassword,
+  validateNewPassword,
   type ValidationErrors,
 } from "@/lib/validation";
 import Link from "next/link";
@@ -17,7 +17,7 @@ const API_BASE = "http://localhost:8080";
 
 function validatePasswords(password: string, confirmPassword: string): ValidationErrors {
   const errors: ValidationErrors = {};
-  const passwordError = validatePassword(
+  const passwordError = validateNewPassword(
     password,
     "新しいパスワードを入力してください",
   );

--- a/src/app/password-reset/new/page.tsx
+++ b/src/app/password-reset/new/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import EyeIcon from "@/components/EyeIcon";
 import WindowPanel from "@/components/WindowPanel";
 import {
+  removePasswordSpaces,
   validateConfirmPassword,
   validatePassword,
   type ValidationErrors,
@@ -177,7 +178,7 @@ export default function PasswordResetNewPage() {
                   id="password"
                   type={showPassword ? "text" : "password"}
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
+                  onChange={(e) => setPassword(removePasswordSpaces(e.target.value))}
                   autoComplete="new-password"
                   placeholder="8文字以上、127文字以内"
                   className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
@@ -207,7 +208,7 @@ export default function PasswordResetNewPage() {
                   id="confirmPassword"
                   type={showConfirmPassword ? "text" : "password"}
                   value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  onChange={(e) => setConfirmPassword(removePasswordSpaces(e.target.value))}
                   onBlur={handleConfirmPasswordBlur}
                   autoComplete="new-password"
                   placeholder="パスワードを再入力してください"

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -11,7 +11,10 @@ import {
   validateConfirmPassword,
   validateEmail,
   validatePassword,
+  removePasswordSpaces,
+  removeUserNameSpaces,
   validateVerificationCode,
+  validateUserName,
   type ValidationErrors,
 } from "@/lib/validation";
 import Link from "next/link";
@@ -26,14 +29,12 @@ function validateRegister(
 ): ValidationErrors {
   const errors: ValidationErrors = {};
 
-  if (!name) {
-    errors.name = "ユーザー名を入力してください";
-  }
-
+  const nameError = validateUserName(name);
   const emailError = validateEmail(email);
   const passwordError = validatePassword(password);
   const confirmPasswordError = validateConfirmPassword(password, confirmPassword);
 
+  if (nameError) errors.name = nameError;
   if (emailError) errors.email = emailError;
   if (passwordError) errors.password = passwordError;
   if (confirmPasswordError) errors.confirmPassword = confirmPasswordError;
@@ -248,9 +249,9 @@ export default function RegisterPage() {
                   id="name"
                   type="text"
                   value={name}
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e) => setName(removeUserNameSpaces(e.target.value))}
                   autoComplete="username"
-                  placeholder="山田 太郎"
+                  placeholder="山田太郎"
                   className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
                 />
               </div>
@@ -289,7 +290,7 @@ export default function RegisterPage() {
                     id="password"
                     type={showPassword ? "text" : "password"}
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => setPassword(removePasswordSpaces(e.target.value))}
                     autoComplete="new-password"
                     placeholder="8文字以上、127文字以内"
                     className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
@@ -319,7 +320,7 @@ export default function RegisterPage() {
                     id="confirmPassword"
                     type={showConfirmPassword ? "text" : "password"}
                     value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    onChange={(e) => setConfirmPassword(removePasswordSpaces(e.target.value))}
                     autoComplete="new-password"
                     placeholder="パスワードを再入力してください"
                     className="w-full border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 pr-12 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -10,7 +10,7 @@ import { useResendCooldown } from "@/hooks/useResendCooldown";
 import {
   validateConfirmPassword,
   validateEmail,
-  validatePassword,
+  validateNewPassword,
   removePasswordSpaces,
   removeUserNameSpaces,
   validateVerificationCode,
@@ -31,7 +31,7 @@ function validateRegister(
 
   const nameError = validateUserName(name);
   const emailError = validateEmail(email);
-  const passwordError = validatePassword(password);
+  const passwordError = validateNewPassword(password);
   const confirmPasswordError = validateConfirmPassword(password, confirmPassword);
 
   if (nameError) errors.name = nameError;
@@ -252,6 +252,7 @@ export default function RegisterPage() {
                   onChange={(e) => setName(removeUserNameSpaces(e.target.value))}
                   autoComplete="username"
                   placeholder="山田太郎"
+                  maxLength={50}
                   className="border border-slate-400 bg-[#0d1b3e]/80 px-4 py-2 text-lg text-white outline-none placeholder:text-slate-400 focus:border-slate-100"
                 />
               </div>

--- a/src/components/VerificationCodeForm.tsx
+++ b/src/components/VerificationCodeForm.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { removeVerificationCodeSpaces } from "@/lib/validation";
+
 type VerificationCodeFormProps = {
   verificationCode: string;
   onCodeChange: (code: string) => void;
@@ -61,7 +63,7 @@ export default function VerificationCodeForm({
           id="verificationCode"
           type="text"
           value={verificationCode}
-          onChange={(e) => onCodeChange(e.target.value)}
+          onChange={(e) => onCodeChange(removeVerificationCodeSpaces(e.target.value))}
           placeholder="認証コードを入力"
           inputMode="numeric"
           autoComplete="one-time-code"

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,14 +1,9 @@
 export type ValidationErrors = Record<string, string | undefined>;
 
-const USER_NAME_SPACE_PATTERN = /\s/;
-const USER_NAME_SPACES_PATTERN = /\s/g;
-const PASSWORD_SPACE_PATTERN = /\s/;
-const PASSWORD_SPACES_PATTERN = /\s/g;
-const VERIFICATION_CODE_SPACE_PATTERN = /\s/;
-const VERIFICATION_CODE_SPACES_PATTERN = /\s/g;
+const SPACE_PATTERN = /\s/;
 
 export function removeUserNameSpaces(name: string): string {
-  return name.replace(USER_NAME_SPACES_PATTERN, "");
+  return name.replace(/\s/g, "");
 }
 
 export function validateUserName(name: string): string | undefined {
@@ -16,7 +11,7 @@ export function validateUserName(name: string): string | undefined {
     return "ユーザー名を入力してください";
   }
 
-  if (USER_NAME_SPACE_PATTERN.test(name)) {
+  if (SPACE_PATTERN.test(name)) {
     return "ユーザー名にスペースは使用できません";
   }
 
@@ -28,7 +23,7 @@ export function validateUserName(name: string): string | undefined {
 }
 
 export function removePasswordSpaces(password: string): string {
-  return password.replace(PASSWORD_SPACES_PATTERN, "");
+  return password.replace(/\s/g, "");
 }
 
 export function validateEmail(email: string): string | undefined {
@@ -79,7 +74,7 @@ export function validateNewPassword(
     return passwordError;
   }
 
-  if (PASSWORD_SPACE_PATTERN.test(password)) {
+  if (SPACE_PATTERN.test(password)) {
     return "パスワードにスペースは使用できません";
   }
 
@@ -118,7 +113,7 @@ export function validateCurrentPassword(password: string): string | undefined {
 }
 
 export function removeVerificationCodeSpaces(code: string): string {
-  return code.replace(VERIFICATION_CODE_SPACES_PATTERN, "");
+  return code.replace(/\s/g, "");
 }
 
 export function validateVerificationCode(code: string): string | undefined {
@@ -126,7 +121,7 @@ export function validateVerificationCode(code: string): string | undefined {
     return "認証コードを入力してください";
   }
 
-  if (VERIFICATION_CODE_SPACE_PATTERN.test(code)) {
+  if (SPACE_PATTERN.test(code)) {
     return "認証コードにスペースは使用できません";
   }
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,11 +1,11 @@
 export type ValidationErrors = Record<string, string | undefined>;
 
-const USER_NAME_SPACE_PATTERN = /[ 　]/;
-const USER_NAME_SPACES_PATTERN = /[ 　]/g;
-const PASSWORD_SPACE_PATTERN = /[ 　]/;
-const PASSWORD_SPACES_PATTERN = /[ 　]/g;
-const VERIFICATION_CODE_SPACE_PATTERN = /[ 　]/;
-const VERIFICATION_CODE_SPACES_PATTERN = /[ 　]/g;
+const USER_NAME_SPACE_PATTERN = /\s/;
+const USER_NAME_SPACES_PATTERN = /\s/g;
+const PASSWORD_SPACE_PATTERN = /\s/;
+const PASSWORD_SPACES_PATTERN = /\s/g;
+const VERIFICATION_CODE_SPACE_PATTERN = /\s/;
+const VERIFICATION_CODE_SPACES_PATTERN = /\s/g;
 
 export function removeUserNameSpaces(name: string): string {
   return name.replace(USER_NAME_SPACES_PATTERN, "");
@@ -67,6 +67,18 @@ export function validatePassword(
     return emptyMessage;
   }
 
+  return undefined;
+}
+
+export function validateNewPassword(
+  password: string,
+  emptyMessage = "パスワードを入力してください",
+): string | undefined {
+  const passwordError = validatePassword(password, emptyMessage);
+  if (passwordError) {
+    return passwordError;
+  }
+
   if (PASSWORD_SPACE_PATTERN.test(password)) {
     return "パスワードにスペースは使用できません";
   }
@@ -98,10 +110,6 @@ export function validateCurrentPassword(password: string): string | undefined {
     return "現在のパスワードを入力してください";
   }
 
-  if (PASSWORD_SPACE_PATTERN.test(password)) {
-    return "現在のパスワードにスペースは使用できません";
-  }
-
   if (password.length > 127) {
     return "現在のパスワードは127文字以内で入力してください";
   }
@@ -120,6 +128,10 @@ export function validateVerificationCode(code: string): string | undefined {
 
   if (VERIFICATION_CODE_SPACE_PATTERN.test(code)) {
     return "認証コードにスペースは使用できません";
+  }
+
+  if (!/^\d+$/.test(code)) {
+    return "認証コードは半角数字で入力してください";
   }
 
   if (code.length !== 6) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,30 @@
 export type ValidationErrors = Record<string, string | undefined>;
 
+const USER_NAME_SPACE_PATTERN = /[ 　]/;
+const USER_NAME_SPACES_PATTERN = /[ 　]/g;
+const PASSWORD_SPACE_PATTERN = /[ 　]/;
+const PASSWORD_SPACES_PATTERN = /[ 　]/g;
+
+export function removeUserNameSpaces(name: string): string {
+  return name.replace(USER_NAME_SPACES_PATTERN, "");
+}
+
+export function validateUserName(name: string): string | undefined {
+  if (!name) {
+    return "ユーザー名を入力してください";
+  }
+
+  if (USER_NAME_SPACE_PATTERN.test(name)) {
+    return "ユーザー名にスペースは使用できません";
+  }
+
+  return undefined;
+}
+
+export function removePasswordSpaces(password: string): string {
+  return password.replace(PASSWORD_SPACES_PATTERN, "");
+}
+
 export function validateEmail(email: string): string | undefined {
   if (!email) {
     return "メールアドレスを入力してください";
@@ -34,6 +59,10 @@ export function validatePassword(
 ): string | undefined {
   if (!password) {
     return emptyMessage;
+  }
+
+  if (PASSWORD_SPACE_PATTERN.test(password)) {
+    return "パスワードにスペースは使用できません";
   }
 
   if (password.length < 8 || password.length > 127) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -4,6 +4,8 @@ const USER_NAME_SPACE_PATTERN = /[ 　]/;
 const USER_NAME_SPACES_PATTERN = /[ 　]/g;
 const PASSWORD_SPACE_PATTERN = /[ 　]/;
 const PASSWORD_SPACES_PATTERN = /[ 　]/g;
+const VERIFICATION_CODE_SPACE_PATTERN = /[ 　]/;
+const VERIFICATION_CODE_SPACES_PATTERN = /[ 　]/g;
 
 export function removeUserNameSpaces(name: string): string {
   return name.replace(USER_NAME_SPACES_PATTERN, "");
@@ -16,6 +18,10 @@ export function validateUserName(name: string): string | undefined {
 
   if (USER_NAME_SPACE_PATTERN.test(name)) {
     return "ユーザー名にスペースは使用できません";
+  }
+
+  if (name.length > 50) {
+    return "ユーザー名は50文字以内で入力してください";
   }
 
   return undefined;
@@ -87,9 +93,37 @@ export function validateConfirmPassword(
   return undefined;
 }
 
+export function validateCurrentPassword(password: string): string | undefined {
+  if (!password) {
+    return "現在のパスワードを入力してください";
+  }
+
+  if (PASSWORD_SPACE_PATTERN.test(password)) {
+    return "現在のパスワードにスペースは使用できません";
+  }
+
+  if (password.length > 127) {
+    return "現在のパスワードは127文字以内で入力してください";
+  }
+
+  return undefined;
+}
+
+export function removeVerificationCodeSpaces(code: string): string {
+  return code.replace(VERIFICATION_CODE_SPACES_PATTERN, "");
+}
+
 export function validateVerificationCode(code: string): string | undefined {
-  if (!code.trim()) {
+  if (!code) {
     return "認証コードを入力してください";
+  }
+
+  if (VERIFICATION_CODE_SPACE_PATTERN.test(code)) {
+    return "認証コードにスペースは使用できません";
+  }
+
+  if (code.length !== 6) {
+    return "6桁の認証コードを入力してください";
   }
 
   return undefined;


### PR DESCRIPTION
## 概要

ユーザー名・パスワード・認証コードの入力バリデーションを整理しました。

## 主な変更内容

- ユーザー名のバリデーションを共通化
- ユーザー名に半角スペース・全角スペースを入力できないように修正
- ユーザー名を50文字以内に制限
- 新規登録画面のユーザー名入力に共通バリデーションを適用
- アカウント設定のユーザー名変更モーダルに共通バリデーションを適用
- パスワードに半角スペース・全角スペースを入力できないように修正
- ログイン・新規登録・パスワード再設定・パスワード変更画面のパスワード入力にスペース除去処理を追加
- 現在のパスワードを127文字以内に制限
- 認証コードを6桁必須に変更
- 認証コードに半角スペース・全角スペースを入力できないように修正

## 確認内容

- `npm run lint` が成功すること
- `npm run build` が成功すること
- 新規登録画面でユーザー名に半角スペースを入力しても反映されないこと
- 新規登録画面でユーザー名に全角スペースを入力しても反映されないこと
- 新規登録画面でユーザー名が50文字を超える場合にエラーメッセージが表示されること
- アカウント設定のユーザー名変更モーダルで半角スペースを入力しても反映されないこと
- アカウント設定のユーザー名変更モーダルで全角スペースを入力しても反映されないこと
- ログイン画面でパスワードに半角スペースを入力しても反映されないこと
- ログイン画面でパスワードに全角スペースを入力しても反映されないこと
- 新規登録画面でパスワードに半角スペース・全角スペースを入力しても反映されないこと
- パスワード再設定画面でパスワードに半角スペース・全角スペースを入力しても反映されないこと
- アカウント設定のパスワード変更画面で現在のパスワードが127文字を超える場合にエラーメッセージが表示されること
- 認証コードが未入力の場合にエラーメッセージが表示されること
- 認証コードが6桁未満の場合にエラーメッセージが表示されること
- 認証コードに半角スペース・全角スペースを入力しても反映されないこと