### PR TITLE
ユーザーアイコン画像アップロードAPIを追加

### DIFF
--- a/src/app/account-settings/page.tsx
+++ b/src/app/account-settings/page.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/lib/validation";
 
 const MAX_NAME_LENGTH = 50;
+const MAX_ICON_FILE_SIZE = 5 * 1024 * 1024;
+const ALLOWED_ICON_FILE_TYPES = ["image/png", "image/jpeg", "image/webp"];
 
 const editIcon = (
   <svg
@@ -251,6 +253,16 @@ export default function AccountSettingsPage() {
     const file = e.target.files?.[0];
 
     if (!file || !user) return;
+
+    if (!ALLOWED_ICON_FILE_TYPES.includes(file.type)) {
+      setIconErrorMessage("PNG、JPEG、WebP形式の画像を選択してください");
+      return;
+    }
+
+    if (file.size > MAX_ICON_FILE_SIZE) {
+      setIconErrorMessage("画像サイズは5MB以下にしてください");
+      return;
+    }
 
     const formData = new FormData();
     formData.append("file", file);

--- a/src/app/account-settings/page.tsx
+++ b/src/app/account-settings/page.tsx
@@ -166,8 +166,11 @@ type User = {
 export default function AccountSettingsPage() {
   const router = useRouter();
   const { updateCurrentUser } = useCurrentUser();
+  const iconInputRef = useRef<HTMLInputElement>(null);
   const [user, setUser] = useState<User | null>(null);
   const [showModal, setShowModal] = useState(false);
+  const [iconErrorMessage, setIconErrorMessage] = useState("");
+  const [isUploadingIcon, setIsUploadingIcon] = useState(false);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -244,6 +247,50 @@ export default function AccountSettingsPage() {
     }
   };
 
+  const handleIconFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file || !user) return;
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    setIsUploadingIcon(true);
+    setIconErrorMessage("");
+
+    try {
+      const res = await fetchWithAuth(`/api/users/${user.id}/icon`, {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const data: { message?: string } = await res.json().catch(() => ({}));
+        throw new Error(data.message ?? "画像のアップロードに失敗しました");
+      }
+
+      const data: User = await res.json();
+      const iconImage = data.iconImage
+        ? `${data.iconImage}?t=${Date.now()}`
+        : data.iconImage;
+
+      setUser({ ...data, iconImage });
+      updateCurrentUser({ ...data, iconImage });
+    } catch (error) {
+      setIconErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "画像のアップロードに失敗しました"
+      );
+    } finally {
+      setIsUploadingIcon(false);
+
+      if (iconInputRef.current) {
+        iconInputRef.current.value = "";
+      }
+    }
+  };
+
   return (
     <>
       <main className="flex flex-1 items-center justify-center">
@@ -253,7 +300,34 @@ export default function AccountSettingsPage() {
           </h1>
 
           <div className="mt-8 flex w-full max-w-md flex-col items-center">
-            {user && <UserAvatar user={user} size="lg" />}
+            <div className="relative">
+              {user && <UserAvatar user={user} size="lg" />}
+
+              <button
+                type="button"
+                onClick={() => iconInputRef.current?.click()}
+                disabled={!user || isUploadingIcon}
+                aria-label="アイコン画像を変更"
+                className="absolute bottom-0 right-0 flex size-10 cursor-pointer items-center justify-center rounded-full border border-white/20 bg-[#13224a] text-white transition-colors hover:border-white/40 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {editIcon}
+              </button>
+            </div>
+
+            <input
+              ref={iconInputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              className="hidden"
+              onChange={handleIconFileChange}
+            />
+
+            <p
+              role={iconErrorMessage ? "alert" : undefined}
+              className={`mt-2 min-h-[20px] text-sm ${iconErrorMessage ? "text-red-400" : "text-transparent"}`}
+            >
+              {iconErrorMessage || "\u00A0"}
+            </p>
 
             <div className="mt-5 w-[80%]">
               <button

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,4 +1,5 @@
 import type { CurrentUser } from "@/contexts/CurrentUserContext";
+import { getApiAssetUrl } from "@/lib/apiConfig";
 
 type UserAvatarSize = "sm" | "lg";
 
@@ -18,14 +19,16 @@ export default function UserAvatar({
   size = "sm",
   className = "",
 }: UserAvatarProps) {
+  const iconImageSrc = user.iconImage ? getApiAssetUrl(user.iconImage) : null;
+
   return (
     <div
       className={`flex items-center justify-center overflow-hidden rounded-full border-white bg-[#123f7a] ${sizeClassNameBySize[size]} ${className}`}
     >
-      {user.iconImage ? (
+      {iconImageSrc ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={user.iconImage}
+          src={iconImageSrc}
           alt=""
           className="size-full object-cover"
         />

--- a/src/lib/apiConfig.ts
+++ b/src/lib/apiConfig.ts
@@ -4,6 +4,14 @@ export function getApiBaseUrl(): string {
   return process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_API_BASE_URL;
 }
 
+export function getApiAssetUrl(path: string): string {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  return `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
 export function getWsBattleUrl(): string {
   if (process.env.NEXT_PUBLIC_WS_URL) {
     return process.env.NEXT_PUBLIC_WS_URL;


### PR DESCRIPTION
## 概要

ユーザーアイコン画像をアカウント設定画面から変更できるようにしました。

## 変更内容

- アカウント設定画面にアイコン画像変更ボタンを追加
- ファイル選択後、`/api/users/{userId}/icon` に画像をアップロードする処理を追加
- アップロード成功後、画面上のアイコン画像と `CurrentUserContext` を更新
- バックエンドから返された画像パスを表示用URLに変換する `getApiAssetUrl` を追加
- `UserAvatar` でアップロード済みアイコン画像を表示できるように修正

