### PR TITLE
二段階認証をコメントアウト

### DIFF
--- a/src/app/password-reset/new/page.tsx
+++ b/src/app/password-reset/new/page.tsx
@@ -31,6 +31,7 @@ function validatePasswords(password: string, confirmPassword: string): Validatio
 export default function PasswordResetNewPage() {
   const router = useRouter();
 
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -47,16 +48,21 @@ export default function PasswordResetNewPage() {
 
     async function checkSession() {
       try {
-        const res = await fetch(`${getApiBaseUrl()}/api/auth/password-reset/verify-session`, {
-          method: "GET",
-          credentials: "include",
-        });
+        // OTP認証を再開する場合は、下記のCookieセッション確認を使用する。
+        // const res = await fetch(`${getApiBaseUrl()}/api/auth/password-reset/verify-session`, {
+        //   method: "GET",
+        //   credentials: "include",
+        // });
+
+        const storedEmail = sessionStorage.getItem("passwordResetEmail");
 
         if (!mounted) return;
 
-        if (!res.ok) {
+        // OTP認証を再開する場合は、storedEmail ではなく !res.ok を確認する。
+        // if (!res.ok) {
+        if (!storedEmail) {
           setIsSessionInvalid(true);
-          setErrors({ general: "有効期限が切れています 再度お試しください" });
+          setErrors({ general: "再度メールアドレスを入力してください" });
 
           setTimeout(() => {
             if (mounted) {
@@ -66,6 +72,8 @@ export default function PasswordResetNewPage() {
 
           return;
         }
+
+        setEmail(storedEmail);
       } catch {
         if (mounted) {
           setErrors({ general: "通信エラーが発生しました" });
@@ -110,12 +118,20 @@ export default function PasswordResetNewPage() {
     setSuccessMessage("");
 
     try {
-      // emailはクッキーでバックエンドが参照するため送信不要
+      // OTP認証を再開する場合は、Cookieからメールアドレスを参照するため password のみ送信する。
+      // const res = await fetch(`${getApiBaseUrl()}/api/auth/password-reset/new`, {
+      //   method: "POST",
+      //   headers: { "Content-Type": "application/json" },
+      //   credentials: "include",
+      //   body: JSON.stringify({ password }),
+      // });
+
+      // OTP認証を一時停止中のため、Cookieではなくメールアドレスも送信する。
       const res = await fetch(`${getApiBaseUrl()}/api/auth/password-reset/new`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ password }),
+        body: JSON.stringify({ email, password }),
       });
 
       if (!res.ok) {
@@ -124,6 +140,7 @@ export default function PasswordResetNewPage() {
       }
 
       setSuccessMessage("パスワードを更新しました");
+      sessionStorage.removeItem("passwordResetEmail");
 
       setTimeout(() => {
         router.push("/login");

--- a/src/app/password-reset/request/page.tsx
+++ b/src/app/password-reset/request/page.tsx
@@ -3,30 +3,32 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
-import VerificationCodeForm from "@/components/VerificationCodeForm";
+// OTP認証を再開する場合はコメントアウトを戻す
+// import VerificationCodeForm from "@/components/VerificationCodeForm";
 import WindowPanel from "@/components/WindowPanel";
-import { useResendCooldown } from "@/hooks/useResendCooldown";
+// import { useResendCooldown } from "@/hooks/useResendCooldown";
 import {
   validateEmail,
-  validateVerificationCode,
+  // validateVerificationCode,
   type ValidationErrors,
 } from "@/lib/validation";
 import Link from "next/link";
-import { getApiBaseUrl } from "@/lib/apiConfig";
+// import { getApiBaseUrl } from "@/lib/apiConfig";
 
 export default function PasswordResetRequestPage() {
-  const [step, setStep] = useState<"request" | "verify">("request");
+  // OTP認証を再開する場合はコメントアウトを戻す
+  // const [step, setStep] = useState<"request" | "verify">("request");
 
   const [email, setEmail] = useState("");
-  const [verificationCode, setVerificationCode] = useState("");
+  // const [verificationCode, setVerificationCode] = useState("");
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isResending, setIsResending] = useState(false);
-  const { resendCooldown, resendSuccess, startResendCooldown } =
-    useResendCooldown();
+  // const [isResending, setIsResending] = useState(false);
+  // const { resendCooldown, resendSuccess, startResendCooldown } =
+  //   useResendCooldown();
 
   const [errors, setErrors] = useState<ValidationErrors>({});
-  const [otpLimitMessage, setOtpLimitMessage] = useState("");
+  // const [otpLimitMessage, setOtpLimitMessage] = useState("");
 
   const router = useRouter();
 
@@ -44,31 +46,40 @@ export default function PasswordResetRequestPage() {
     setErrors({});
 
     try {
-      const res = await fetch(`${getApiBaseUrl()}/api/auth/password-reset/request`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ email }),
-      });
+      // OTP認証を再開する場合は、下記の認証コード発行APIを使用する。
+      // const res = await fetch(`${getApiBaseUrl()}/api/auth/password-reset/request`, {
+      //   method: "POST",
+      //   headers: { "Content-Type": "application/json" },
+      //   credentials: "include",
+      //   body: JSON.stringify({ email }),
+      // });
 
-      if (!res.ok) {
-        if (res.status === 404) {
-          setErrors({ email: "登録されていないメールアドレスです" });
-          return;
-        }
+      // if (!res.ok) {
+      //   if (res.status === 404) {
+      //     setErrors({ email: "登録されていないメールアドレスです" });
+      //     return;
+      //   }
 
-        setErrors({ general: "送信に失敗しました" });
-        return;
-      }
+      //   setErrors({ general: "送信に失敗しました" });
+      //   return;
+      // }
 
-      setStep("verify");
-      setErrors({});
+      // setStep("verify");
+      // setErrors({});
+      // return;
+
+      // OTP認証を一時停止中のため、認証コード発行APIは呼ばずに次画面へ進める。
+      sessionStorage.setItem("passwordResetEmail", email);
+      router.push("/password-reset/new");
     } catch {
       setErrors({ general: "通信エラーが発生しました" });
     } finally {
       setIsSubmitting(false);
     }
   }
+
+  /*
+  OTP認証を再開する場合はコメントアウトを戻す
 
   async function handleVerify(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -145,21 +156,22 @@ export default function PasswordResetRequestPage() {
       setIsResending(false);
     }
   }
+  */
 
   return (
     <main className="flex flex-1 items-center justify-center overflow-auto">
       <div className="[&>section]:min-h-[400px] [&>section]:min-w-[535px]">
         <WindowPanel>
           <h1 className="text-3xl font-bold tracking-wide text-white">
-            {step === "verify" ? "認証コードを入力" : "パスワード再設定"}
+            パスワード再設定
+            {/* OTP認証を再開する場合: {step === "verify" ? "認証コードを入力" : "パスワード再設定"} */}
           </h1>
 
-          {step === "request" ? (
-            <form
-              onSubmit={handleRequest}
-              noValidate
-              className="mt-6 flex w-full max-w-sm flex-col gap-5"
-            >
+          <form
+            onSubmit={handleRequest}
+            noValidate
+            className="mt-6 flex w-full max-w-sm flex-col gap-5"
+          >
               
               {/* 通信エラー */}
               <p
@@ -209,8 +221,11 @@ export default function PasswordResetRequestPage() {
                   </span>
                 </Link>
               </p>
-            </form>
-          ) : (
+          </form>
+          {/*
+            OTP認証を再開する場合は、上のフォームを step === "request" の分岐に戻し、
+            step === "verify" で下記を表示する。
+
             <VerificationCodeForm
               verificationCode={verificationCode}
               onCodeChange={setVerificationCode}
@@ -223,7 +238,7 @@ export default function PasswordResetRequestPage() {
               resendCooldown={resendCooldown}
               resendSuccess={resendSuccess}
             />
-          )}
+          */}
         </WindowPanel>
       </div>
     </main>

--- a/src/app/register/RegisterForm.tsx
+++ b/src/app/register/RegisterForm.tsx
@@ -4,16 +4,17 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 import EyeIcon from "@/components/EyeIcon";
-import VerificationCodeForm from "@/components/VerificationCodeForm";
+// OTP認証を再開する場合はコメントアウトを戻す
+// import VerificationCodeForm from "@/components/VerificationCodeForm";
 import WindowPanel from "@/components/WindowPanel";
-import { useResendCooldown } from "@/hooks/useResendCooldown";
+// import { useResendCooldown } from "@/hooks/useResendCooldown";
 import {
   validateConfirmPassword,
   validateEmail,
   validateNewPassword,
   removePasswordSpaces,
   removeUserNameSpaces,
-  validateVerificationCode,
+  // validateVerificationCode,
   validateUserName,
   type ValidationErrors,
 } from "@/lib/validation";
@@ -44,7 +45,8 @@ function validateRegister(
 export default function RegisterForm() {
   const router = useRouter();
 
-  const [step, setStep] = useState<"register" | "verify">("register");
+  // OTP認証を再開する場合はコメントアウトを戻す
+  // const [step, setStep] = useState<"register" | "verify">("register");
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -52,15 +54,15 @@ export default function RegisterForm() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [verificationCode, setVerificationCode] = useState("");
+  // const [verificationCode, setVerificationCode] = useState("");
 
   const [errors, setErrors] = useState<ValidationErrors>({});
-  const [successMessage, setSuccessMessage] = useState("");
-  const [otpLimitMessage, setOtpLimitMessage] = useState("");
+  // const [successMessage, setSuccessMessage] = useState("");
+  // const [otpLimitMessage, setOtpLimitMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isResending, setIsResending] = useState(false);
-  const { resendCooldown, resendSuccess, startResendCooldown } =
-    useResendCooldown();
+  // const [isResending, setIsResending] = useState(false);
+  // const { resendCooldown, resendSuccess, startResendCooldown } =
+  //   useResendCooldown();
 
   async function handleRegister(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -78,10 +80,20 @@ export default function RegisterForm() {
 
     setIsSubmitting(true);
     setErrors({});
-    setSuccessMessage("");
+    // OTP認証を再開する場合はコメントアウトを戻す
+    // setSuccessMessage("");
 
     try {
-      const res = await fetch(`${getApiBaseUrl()}/api/auth/otp/register`, {
+      // OTP認証を再開する場合は、下記の認証コード発行APIを使用する。
+      // const res = await fetch(`${getApiBaseUrl()}/api/auth/otp/register`, {
+      //   method: "POST",
+      //   headers: { "Content-Type": "application/json" },
+      //   credentials: "include",
+      //   body: JSON.stringify({ name, email, password }),
+      // });
+
+      // OTP認証を一時停止中のため、認証コード発行APIは呼ばずに本登録へ進める。
+      const res = await fetch(`${getApiBaseUrl()}/api/auth/registerUser`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -105,13 +117,20 @@ export default function RegisterForm() {
         return;
       }
 
-      setStep("verify");
+      // OTP認証を再開する場合は、登録完了ではなく認証コード入力へ進める。
+      // setStep("verify");
+      // return;
+
+      router.push("/login");
     } catch {
       setErrors({ general: "通信エラーが発生しました" });
     } finally {
       setIsSubmitting(false);
     }
   }
+
+  /*
+  OTP認証を再開する場合はコメントアウトを戻す
 
   async function handleVerify(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -206,27 +225,22 @@ export default function RegisterForm() {
       setIsResending(false);
     }
   }
+  */
 
   return (
     <main className="flex flex-1 items-center justify-center overflow-auto">
-      <div
-        className={
-          step === "verify"
-            ? "[&>section]:min-h-[400px] [&>section]:min-w-[535px]"
-            : "[&>section]:min-h-[500px] [&>section]:min-w-[535px]"
-        }
-      >
+      <div className="[&>section]:min-h-[500px] [&>section]:min-w-[535px]">
         <WindowPanel>
           <h1 className="text-3xl font-bold tracking-wide text-white">
-            {step === "verify" ? "認証コードを入力" : "新規登録"}
+            新規登録
+            {/* OTP認証を再開する場合: {step === "verify" ? "認証コードを入力" : "新規登録"} */}
           </h1>
 
-          {step === "register" ? (
-            <form
-              onSubmit={handleRegister}
-              noValidate
-              className="mt-6 flex w-full max-w-sm flex-col gap-5"
-            >
+          <form
+            onSubmit={handleRegister}
+            noValidate
+            className="mt-6 flex w-full max-w-sm flex-col gap-5"
+          >
               {/* 通信エラー */}
               <p
                 role={errors.general ? "alert" : undefined}
@@ -353,8 +367,11 @@ export default function RegisterForm() {
                   </span>
                 </Link>
               </p>
-            </form>
-          ) : (
+          </form>
+          {/*
+            OTP認証を再開する場合は、上のフォームを step === "register" の分岐に戻し、
+            step === "verify" で下記を表示する。
+
             <VerificationCodeForm
               verificationCode={verificationCode}
               onCodeChange={setVerificationCode}
@@ -368,7 +385,7 @@ export default function RegisterForm() {
               resendCooldown={resendCooldown}
               resendSuccess={resendSuccess}
             />
-          )}
+          */}
         </WindowPanel>
       </div>
     </main>


### PR DESCRIPTION
## 概要

二段階認証（OTP）を一時停止し、新規登録とパスワード再設定を認証コードなしで進められるようにしました。

## 主な変更内容

- 新規登録時のOTP発行API呼び出しをコメントアウト

- 新規登録時のOTP検証処理をコメントアウト

- 新規登録時の認証コード入力フォーム表示をコメントアウト

- 新規登録時は `name`, `email`, `password` を `POST /api/auth/registerUser` へ送信するように変更

- パスワード再設定時のOTP発行API呼び出しをコメントアウト

- パスワード再設定時のOTP検証処理をコメントアウト

- パスワード再設定時の認証コード入力フォーム表示をコメントアウト

- パスワード再設定では入力したメールアドレスを一時的に保持し、新しいパスワード設定画面へ遷移するように変更

- 新しいパスワード設定時は `email`, `password` を `POST /api/auth/password-reset/new` へ送信するように変更

- OTP再開時に戻しやすいよう、既存処理は削除せずコメントアウトで保持

## 使用するAPI

```text

POST /api/auth/registerUser

POST /api/auth/password-reset/new

```

## 今回使用しなくなるAPI

```text

POST /api/auth/otp/register

POST /api/auth/otp/verify

POST /api/auth/password-reset/request

POST /api/auth/password-reset/verify

GET  /api/auth/password-reset/verify-session

```

## 確認内容

- `npm run lint` が成功すること

- `npm run build` が成功すること

- 新規登録画面で認証コード入力画面に遷移しないこと

- パスワード再設定申請画面で認証コード入力画面に遷移しないこと

- パスワード再設定申請後、新しいパスワード設定画面へ遷移すること

## 補足

バックエンド側でも、OTPなしで以下のAPIを使用できるように変更が必要です。

```text

POST /api/auth/registerUser

body: { name, email, password }

POST /api/auth/password-reset/new

body: { email, password }

```